### PR TITLE
Skip coerce when IOMetadata is nil

### DIFF
--- a/trigger/handler.go
+++ b/trigger/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/project-flogo/core/data/coerce"
 
 	"github.com/project-flogo/core/action"
@@ -147,13 +148,13 @@ func (h *handlerImpl) Handle(ctx context.Context, triggerData interface{}) (map[
 		inputMap = triggerValues
 	}
 
-	ioMd := act.act.IOMetadata()
-
-	for name, tv := range ioMd.Input {
-		if val, ok  := inputMap[name]; ok {
-			inputMap[name], err = coerce.ToType(val, tv.Type())
-			if err != nil {
-				return nil, err
+	if ioMd := act.act.IOMetadata(); ioMd != nil {
+		for name, tv := range ioMd.Input {
+			if val, ok := inputMap[name]; ok {
+				inputMap[name], err = coerce.ToType(val, tv.Type())
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Action doesn't always have IOMetadata: in the case of an action created with a closure through the API there isn't any IOMetadata.