### PR TITLE
Activity Context Logger

### DIFF
--- a/api/support.go
+++ b/api/support.go
@@ -3,10 +3,11 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"github.com/project-flogo/core/support/log"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/project-flogo/core/support/log"
 
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/activity"
@@ -261,7 +262,7 @@ func (aCtx *activityContext) GetSharedTempData() map[string]interface{} {
 }
 
 func (aCtx *activityContext) Logger() log.Logger {
-	return nil
+	return log.RootLogger()
 }
 
 func (aCtx *activityContext) GetInputObject(input data.StructValue) error {

--- a/api/support.go
+++ b/api/support.go
@@ -262,7 +262,7 @@ func (aCtx *activityContext) GetSharedTempData() map[string]interface{} {
 }
 
 func (aCtx *activityContext) Logger() log.Logger {
-	return log.RootLogger()
+	return log.ChildLogger(log.RootLogger(), "activity")
 }
 
 func (aCtx *activityContext) GetInputObject(input data.StructValue) error {


### PR DESCRIPTION
When trying to get the logger from the activity context a nil pointer error was being thrown. @fm-tibco not sure if you want to get the logger from a different method?

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7515b5]
goroutine 20 [running]:
github.com/project-flogo/contrib/activity/log.(*Activity).Eval(0xaf5450, 0x8a41a0, 0xc00018a1d0, 0x0, 0x0, 0x0)
	C:/Users/melli/go/src/github.com/project-flogo/contrib/activity/log/activity.go:67 +0x4f5
github.com/project-flogo/core/api.EvalActivity(0x8a1640, 0xaf5450, 0x7d4840, 0xc0001a01a0, 0x0, 0x0, 0x0)
	C:/Users/melli/go/src/github.com/project-flogo/core/api/support.go:218 +0x350
main.RunActivities(0x8a3340, 0xc00005e080, 0xc00018c3f0, 0x0, 0x0, 0x0)
	c:/Users/melli/Downloads/flogo_api/main.go:51 +0x27e
github.com/project-flogo/core/api.(*proxyAction).Run(0xc000052fa0, 0x8a3340, 0xc00005e080, 0xc00018c3f0, 0x0, 0x0, 0x0)
	C:/Users/melli/go/src/github.com/project-flogo/core/api/support.go:137 +0x82
github.com/project-flogo/core/engine/runner.ActionWorker.Start.func1(0x1, 0xaf5450, 0xc000050120, 0xc00009a600, 0xc000050180, 0x8a49c0, 0xc000052da0)
	C:/Users/melli/go/src/github.com/project-flogo/core/engine/runner/worker.go:100 +0x474
created by github.com/project-flogo/core/engine/runner.ActionWorker.Start
	C:/Users/melli/go/src/github.com/project-flogo/core/engine/runner/worker.go:76 +0x89
```