### PR TITLE
Fix expressions syntax in default flogo.json

### DIFF
--- a/examples/engine/flogo.json
+++ b/examples/engine/flogo.json
@@ -23,7 +23,7 @@
               "flowURI": "res://flow:simple_flow"
             },
             "input": {
-              "in": "$.pathParams.val"
+              "in": "=$.pathParams.val"
             }
           }
         }
@@ -50,7 +50,7 @@
             "activity": {
               "ref": "github.com/project-flogo/contrib/activity/log",
               "input": {
-                "message": "$flow.in",
+                "message": "=$flow.in",
                 "flowInfo": "false",
                 "addToFlow": "false"
               }


### PR DESCRIPTION
The expressions in the default *flogo.json* template (used by ```flogo create``` command of the [Flogo CLI](https://github.com/project-flogo/cli)) are missing the leading *=* sign.

As a result expressions are not evaluated, for instance with default application created by the Flogo CLI:

```
547043892330439187	INFO	[flogo.engine] -	Starting app [ test-app ] with version [ 0.0.1 ]
1547043892330464572	INFO	[flogo.engine] -	Engine Starting...
1547043892330471263	INFO	[flogo.engine] -	Starting Services...
1547043892330499314	INFO	[flogo.engine] -	Started Services
1547043892330508566	INFO	[flogo.engine] -	Starting Application...
1547043892330518960	INFO	[flogo] -	Starting Triggers...
1547043892330609569	INFO	[flogo] -	Trigger [ my_rest_trigger ]: Started
1547043892330617442	INFO	[flogo] -	Triggers Started
1547043892330625464	INFO	[flogo.engine] -	Application Started
1547043892330629550	INFO	[flogo.engine] -	Engine Started
1547043895032521708	INFO	[flogo.activity.log] -	$flow.in
1547043895032608576	INFO	[flogo.flow] -	Instance [8537e087e63735ac2c95d52425ff09a9] Done
```

Notice the **$flow.in** instead of the real value.