### PR TITLE
Set the app property manager as the default property manager

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -32,6 +32,7 @@ func New(config *Config, runner action.Runner, options ...Option) (*App, error) 
 	}
 
 	app.propManager = property.NewManager(properties)
+	property.SetDefaultManager(app.propManager)
 
 	for _, option := range options {
 		option(app)


### PR DESCRIPTION
By setting the app property manager as the default property manager, it solves the issue of properties not being evaluated in expression such as ```=$property[my_property]``` in *flogo.json*.
AFAIK, this fix concerns external resolution as well as classic resolution (from *flogo.json*) as well.