### PR TITLE
Fix JSON property resolver

### DIFF
--- a/app/propertyresolver/json.go
+++ b/app/propertyresolver/json.go
@@ -43,6 +43,10 @@ func init() {
 					logger.Errorf("Can not read - %s due to error - %v", filePath, e)
 					panic("")
 				}
+
+				for k, v := range props {
+					preload[k] = v
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Properties loaded from JSON files need to be stored in the ```preload``` map.