### PR TITLE
Simplify properties post-processing implementation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -34,10 +34,6 @@ func New(config *Config, runner action.Runner, options ...Option) (*App, error) 
 	app.propManager = property.NewManager(properties)
 	property.SetDefaultManager(app.propManager)
 
-	for _, option := range options {
-		option(app)
-	}
-
 	resources := make(map[string]*resource.Resource, len(config.Resources))
 	app.resManager = resource.NewManager(resources)
 
@@ -84,9 +80,9 @@ func ContinueOnError(a *App) error {
 	return nil
 }
 
-func FinalizeProperties(useExternalResolvers bool, processors ...property.PostProcessor) func(*App) error {
+func FinalizeProperties(processors ...property.PostProcessor) func(*App) error {
 	return func(a *App) error {
-		return a.propManager.Finalize(useExternalResolvers, processors...)
+		return a.propManager.Finalize(processors...)
 	}
 }
 

--- a/data/property/manager.go
+++ b/data/property/manager.go
@@ -1,9 +1,5 @@
 package property
 
-import (
-	"github.com/project-flogo/core/support/log"
-)
-
 func init() {
 	SetDefaultManager(NewManager(make(map[string]interface{})))
 }
@@ -33,21 +29,7 @@ func (m *Manager) GetProperty(name string) (interface{}, bool) {
 	return val, exists
 }
 
-func (m *Manager) Finalize(useExternalResolvers bool, processors ...PostProcessor) error {
-
-	logger := log.RootLogger()
-
-	if useExternalResolvers {
-		for name := range m.properties {
-			newVal, found := ResolveExternally(name)
-
-			if !found {
-				logger.Warnf("Property '%s' could not be resolved using external resolver(s) '%s'. Using default value.", name)
-			} else {
-				m.properties[name] = newVal
-			}
-		}
-	}
+func (m *Manager) Finalize(processors ...PostProcessor) error {
 
 	for _, processor := range processors {
 		processor(m.properties)

--- a/data/property/resolver.go
+++ b/data/property/resolver.go
@@ -23,7 +23,6 @@ func RegisterExternalResolver(resolverType string, resolver ExternalResolver) er
 
 	logger := log.RootLogger()
 
-
 	if resolverType == "" {
 		return fmt.Errorf("'resolverType' must be specified when registering external property resolver")
 	}
@@ -72,4 +71,21 @@ func ResolveExternally(propertyName string) (interface{}, bool) {
 	}
 
 	return nil, false
+}
+
+func ExternalPropertyResolverProcessor(properties map[string]interface{}) error {
+
+	logger := log.RootLogger()
+
+	for name := range properties {
+		newVal, found := ResolveExternally(name)
+
+		if !found {
+			logger.Warnf("Property '%s' could not be resolved using external resolver(s) '%s'. Using default value.", name)
+		} else {
+			properties[name] = newVal
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
# Abstract
The properties post-processing was mixing inline implementation and clean implementation in typed functions.
There was also a bug where the post processings were called twice.

# Details

1. https://github.com/project-flogo/core/compare/master...square-it:property-post-processing?expand=1#diff-886cebc00c073731af1b3da26f11e536L37 : the execution of the options were triggered twice : I deleted the first one.

2. https://github.com/project-flogo/core/compare/master...square-it:property-post-processing?expand=1#diff-ae5650532ac696c0d459a933c48df0a8R76 : external property post processor was moved to the *property* package.

3. https://github.com/project-flogo/core/compare/master...square-it:property-post-processing?expand=1#diff-a6a58e1ba1bcac0ce49fa12af14faaf1R32 : *manager.Finalize* method does not take boolean parameter anymore. Instead the inline implementation at https://github.com/project-flogo/core/compare/master...square-it:property-post-processing?expand=1#diff-a6a58e1ba1bcac0ce49fa12af14faaf1L38 has been moved to a *property.PostProcessor* function (see 2.).