### PR TITLE
Add new format of imports in flogo.json template file

### DIFF
--- a/examples/engine/flogo.json
+++ b/examples/engine/flogo.json
@@ -4,6 +4,11 @@
   "version": "0.0.1",
   "description": "My flogo application description",
   "appModel": "1.0.0",
+  "imports": [
+    "github.com/project-flogo/contrib/activity/log",
+    "github.com/project-flogo/contrib/trigger/rest",
+    "github.com/project-flogo/flow"
+  ],
   "triggers": [
     {
       "id": "my_rest_trigger",

--- a/examples/engine/flogo.json
+++ b/examples/engine/flogo.json
@@ -12,7 +12,7 @@
   "triggers": [
     {
       "id": "my_rest_trigger",
-      "ref": "github.com/project-flogo/contrib/trigger/rest",
+      "type": "rest",
       "settings": {
         "port": "8888"
       },
@@ -23,7 +23,7 @@
             "path": "/test/:val"
           },
           "action": {
-            "ref": "github.com/project-flogo/flow",
+            "type": "flow",
             "settings": {
               "flowURI": "res://flow:simple_flow"
             },
@@ -53,7 +53,7 @@
             "id": "log",
             "name": "Log Message",
             "activity": {
-              "ref": "github.com/project-flogo/contrib/activity/log",
+              "type": "log",
               "input": {
                 "message": "=$flow.in",
                 "flowInfo": "false",

--- a/examples/engine/flogo.json
+++ b/examples/engine/flogo.json
@@ -22,15 +22,17 @@
             "method": "GET",
             "path": "/test/:val"
           },
-          "action": {
-            "type": "flow",
-            "settings": {
-              "flowURI": "res://flow:simple_flow"
-            },
-            "input": {
-              "in": "=$.pathParams.val"
-            }
-          }
+          "actions": [
+            {
+              "type": "flow",
+              "settings": {
+                "flowURI": "res://flow:simple_flow"
+              },
+              "input": {
+                "in": "=$.pathParams.val"
+              }
+	    }
+	  ]
         }
       ]
     }


### PR DESCRIPTION
According to https://github.com/project-flogo/cli/blob/99f31dabada136e9cddc2e5202d97011a7a315bc/util/flogo.go#L103, once an import exists in the *imports* array of a *flogo.json* app descriptor, the legacy imports are not loaded by ```flogo list``` command.

By adding them explicitly we ensure they will be displayed by this command.

Accordingly, the ```flogo install``` command should be changed to add new installed contribution to the *imports* list.

It raises also some questions about how to keep in sync app descriptor and Go code.