### PR TITLE
Fix property pre-processing order

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -34,6 +34,10 @@ func New(config *Config, runner action.Runner, options ...Option) (*App, error) 
 	app.propManager = property.NewManager(properties)
 	property.SetDefaultManager(app.propManager)
 
+	for _, option := range options {
+		option(app)
+	}
+
 	resources := make(map[string]*resource.Resource, len(config.Resources))
 	app.resManager = resource.NewManager(resources)
 
@@ -66,10 +70,6 @@ func New(config *Config, runner action.Runner, options ...Option) (*App, error) 
 	app.triggers, err = app.createTriggers(config.Triggers, runner)
 	if err != nil {
 		return nil, fmt.Errorf("error creating trigger instances - %s", err.Error())
-	}
-
-	for _, option := range options {
-		option(app)
 	}
 
 	return app, nil


### PR DESCRIPTION
This is a fix for https://github.com/project-flogo/core/pull/13.

In fact the properties pre-processing need to be done before initializing resources (such as activities).

There were two occurrences of 
```
	for _, option := range options {
		option(app)
	}
```

but I unfortunately removed the wrong one.