### PR TITLE
Fix test Logger

### DIFF
--- a/support/test/context.go
+++ b/support/test/context.go
@@ -216,5 +216,5 @@ func (c *TestActivityContext) GetSharedTempData() map[string]interface{} {
 }
 
 func (c *TestActivityContext) Logger() log.Logger {
-	return nil
+	return logger
 }


### PR DESCRIPTION
Fix nil pointer error caused by `nil` in activity.Eval() during test