### PR TITLE
Set channels global map to empty map on stop

### DIFF
--- a/engine/channels/channels.go
+++ b/engine/channels/channels.go
@@ -75,6 +75,7 @@ func Stop() error {
 			log.RootLogger().Warnf("error stopping channel '%s', error: %s", channel.name, err.Error())
 		}
 	}
+	channels = make(map[string]*channelImpl)
 
 	active = false
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #
Allows multiple integration tests (in the same test file) in microgateway.

**What is the current behavior?**
channels map is not set to an empty map on stop

**What is the new behavior?**
channels map is set to a new empty map on stop
