### PR TITLE
Support classic and alternate import syntax in flogo.json

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"path"
+	"regexp"
 	"runtime/debug"
 	"strings"
 
@@ -18,12 +19,15 @@ import (
 
 type Option func(*App) error
 
+var flogoImportPattern = regexp.MustCompile(`^(([^ ]*)[ ]+)?([^@:]*)@?([^:]*)?:?(.*)?$`) // extract import path even if there is an alias and/or a version
+
 func New(config *Config, runner action.Runner, options ...Option) (*App, error) {
 
 	app := &App{stopOnError: true, name: config.Name, version: config.Version}
 
 	for _, anImport := range config.Imports {
-		registerImport(anImport)
+		matches := flogoImportPattern.FindStringSubmatch(anImport)
+		registerImport(matches[1] + matches[3] + matches[5]) // alias + module path + relative import path
 	}
 
 	properties := make(map[string]interface{}, len(config.Properties))

--- a/examples/alt/engine/flogo.json
+++ b/examples/alt/engine/flogo.json
@@ -5,9 +5,9 @@
   "description": "My flogo application description",
   "appModel": "1.0.0",
   "imports": [
-    "github.com/project-flogo/contrib/activity/log",
-    "github.com/project-flogo/contrib/trigger/rest",
-    "github.com/project-flogo/flow"
+    "github.com/project-flogo/contrib@latest:/activity/log",
+    "github.com/project-flogo/contrib@latest:/trigger/rest",
+    "github.com/project-flogo/flow@latest"
   ],
   "triggers": [
     {

--- a/examples/engine/flogo.json
+++ b/examples/engine/flogo.json
@@ -5,8 +5,8 @@
   "description": "My flogo application description",
   "appModel": "1.0.0",
   "imports": [
-    "github.com/project-flogo/contrib/activity/log",
-    "github.com/project-flogo/contrib/trigger/rest",
+    "github.com/project-flogo/contrib:/activity/log",
+    "github.com/project-flogo/contrib:/trigger/rest",
     "github.com/project-flogo/flow"
   ],
   "triggers": [


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

> This PR **is required** to be merged before https://github.com/project-flogo/cli/pull/32

**What is the current behavior?**
Currently imports in the "imports" array of *flogo.json* file follow the Go import path syntax (including aliases).
Hence it is not possible to know what is the path to the underlying module (if it exists) neither to specify a custom version.
This complicates the interaction of the Flogo CLI with ```go mod``` commands for instance in the ```flogo create``` command and it prevents the *flogo.json* to recreate an application in a reproducible way (since all declared imports will always used the @latest stable version available).

**What is the new behavior?**
In PR https://github.com/project-flogo/cli/pull/32, a proposal is made to create a new syntax which would be more verbose while remaining readable.

This syntax is aimed at keeping good default values (no version = latest, no alias by default).
The only ~~mandatory~~ add-on is the **:** when the original import path [does not point to a Go module](https://github.com/project-flogo/contrib/tree/master/activity/log) like the *github.com/project-flogo/contrib/activity/log* contribution.
 
So
```
    "github.com/project-flogo/contrib/activity/log",
```
becomes
```
    "github.com/project-flogo/contrib:/activity/log",
```

Notice the **:** separating the path to the module and the relative import path.

Notice also that the *github.com/project-flogo/flow* import is unchanged as it already [points to a Go module](https://github.com/project-flogo/flow/blob/master/go.mod) and it is expected to use latest version.

Update : this new syntax format can totally be mixed with the old one. Using the new one gives more flexibility to manage dependencies under the hood. Hence I suggest to name those two compatible syntaxes the **classic syntax** and the **alternate syntax**.