### PR TITLE
Fix event publishing

### DIFF
--- a/engine/event/emitter.go
+++ b/engine/event/emitter.go
@@ -76,6 +76,4 @@ func (te *Emitter) Publish(evtCtx *Context) {
 			log.RootLogger().Debugf("Event - '%s' is successfully delivered to event listener - '%s'", te.eventType, name)
 		}
 	}
-
-	te.mutex.RUnlock()
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**What is the current behavior?**
At the end of an event publishing, unlocking the mutex twice (once at the end of the function, another time in the defer) results in a panic.

**What is the new behavior?**
Publishing an event is working.