### PR TITLE
Objectmapper compatibility

### DIFF
--- a/data/mapper/deprecated.go
+++ b/data/mapper/deprecated.go
@@ -4,8 +4,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/project-flogo/core/data/coerce"
+	"github.com/project-flogo/core/data/expression"
+	"github.com/project-flogo/core/data/resolve"
+	"sort"
 	"strconv"
+	"strings"
+	"text/scanner"
+	"unicode"
 )
+
+var testExprfactory = expression.NewFactory(resolve.GetBasicResolver())
 
 //DEPRECATED
 type LegacyMappings struct {
@@ -55,29 +64,227 @@ func ConvertLegacyMappings(mappings *LegacyMappings) (input map[string]interface
 
 func convertMappingValue(mapping *LegacyMapping) (interface{}, error) {
 	strType, _ := toString(mapping.Type)
-	switch strType {
-	case "assign", "1":
-		expr, ok := mapping.Value.(string)
-		if ok {
-			return "=" + expr, nil
-		}
-		return mapping.Value, nil
-	case "literal", "2":
-		return mapping.Value, nil
-	case "expression", "3":
-		expr, ok := mapping.Value.(string)
-		if !ok {
-			return nil, fmt.Errorf("invalid expression mapping: '%v'", mapping.Value)
-		}
-		return "=" + expr, nil
-	case "object", "4":
-		return mapping.Value, nil
-	case "array", "5":
-		return mapping.Value, nil
-	default:
-		return 0, errors.New("unsupported mapping type: " + strType)
-	}
+	return convertMapperValue(mapping.Value, strType)
 }
+
+func ToObjectMapping(mappings []*objectMappings) (interface{}, error) {
+
+	sort.Slice(mappings, func(i, j int) bool {
+		return len(mappings[i].paths) < len(mappings[j].paths)
+	})
+
+	//obj := make(map[string]interface{})
+	//toObjectFromPath(obj)
+	return nil, nil
+}
+
+func toObjectFromPath(fields []string, value interface{}, object map[string]interface{}) interface{} {
+	path := fields[0]
+	fieldName := getFieldName(path)
+	if strings.Index(path, "[") >= 0 && strings.HasSuffix(path, "]") {
+		//Make sure the index are integer
+		index, err := strconv.Atoi(getNameInsideBrancket(path))
+		if err == nil {
+			//Array
+			if array, exist := object[fieldName]; !exist {
+				tmpArrray := make([]interface{}, index+1)
+				tmpArrray[index] = make(map[string]interface{})
+				if len(fields) == 1 {
+					tmpArrray[index] = value
+					object[fieldName] = tmpArrray
+					return object
+				} else {
+					object[fieldName] = tmpArrray
+					return toObjectFromPath(fields[1:], value, tmpArrray[index].(map[string]interface{}))
+				}
+			} else {
+				//exist
+				if av, ok := array.([]interface{}); ok {
+					if len(fields) <= 1 {
+						av = Insert(av, index, value)
+						object[fieldName] = av
+						return object
+					} else {
+						if index >= len(av) {
+							av = Insert(av, index, make(map[string]interface{}))
+						} else {
+							av[index] = make(map[string]interface{})
+						}
+						object[fieldName] = av
+						return toObjectFromPath(fields[1:], value, object[fieldName].([]interface{})[index].(map[string]interface{}))
+					}
+				} else {
+					return fmt.Errorf("not an array")
+				}
+			}
+
+		} else {
+			//Not an array
+			if len(fields) == 1 {
+				object[fieldName] = value
+				return object
+			} else {
+				if _, exist := object[fieldName]; !exist {
+					object[fieldName] = map[string]interface{}{}
+				}
+			}
+
+			if len(fields) > 1 {
+				toObjectFromPath(fields[1:], value, object[fieldName].(map[string]interface{}))
+			}
+		}
+
+	} else {
+		//Not an array
+		if len(fields) <= 1 {
+			object[fieldName] = value
+			return object
+		} else {
+			if _, exist := object[fieldName]; !exist {
+				object[fieldName] = map[string]interface{}{}
+			}
+		}
+
+		toObjectFromPath(fields[1:], value, object[path].(map[string]interface{}))
+	}
+	return nil
+}
+
+func Insert(slice []interface{}, index int, value interface{}) []interface{} {
+	if index >= len(slice) {
+		// add to the end of slice in case of index >= len(slice)
+		tmpArray := make([]interface{}, index+1)
+		tmpArray[index] = value
+		copy(tmpArray, slice)
+		return tmpArray
+	}
+	slice[index] = value
+	return slice
+}
+
+func getNameInsideBrancket(fieldName string) string {
+	if strings.Index(fieldName, "[") >= 0 {
+		index := fieldName[strings.Index(fieldName, "[")+1 : strings.Index(fieldName, "]")]
+		return index
+	}
+
+	return ""
+}
+
+type objectMappings struct {
+	fieldName string
+	paths     []string
+	mapping   *LegacyMapping
+}
+
+func getSortedMapto(mappings []*LegacyMapping) (map[string]interface{}, error) {
+	input := make(map[string]interface{})
+	fieldNameMap := make(map[string][]*objectMappings)
+	for _, m := range mappings {
+		field, err := ParseMappingField(m.MapTo)
+		if err != nil {
+			return nil, err
+		}
+		objectLevelFields := field.Getfields()
+		fieldName := getFieldName(objectLevelFields[0])
+		fieldNameMap[fieldName] = append(fieldNameMap[fieldName], &objectMappings{fieldName: fieldName, paths: objectLevelFields[1:], mapping: m})
+	}
+
+	for k, v := range fieldNameMap {
+		if len(v) == 1 {
+			val, err := convertMappingValue(v[0].mapping)
+			if err != nil {
+				return nil, err
+			}
+			input[k] = val
+		}
+
+		if len(v) > 1 {
+
+		}
+	}
+	return nil, nil
+}
+
+func getFieldName(fieldname string) string {
+	if strings.Index(fieldname, "[") > 0 && strings.Index(fieldname, "]") > 0 {
+		return fieldname[:strings.Index(fieldname, "[")]
+	}
+	return fieldname
+}
+
+type LegacyArrayMapping struct {
+	From   interface{}           `json:"from"`
+	To     string                `json:"to"`
+	Type   string                `json:"type"`
+	Fields []*LegacyArrayMapping `json:"fields,omitempty"`
+}
+
+func ParseArrayMapping(arrayDatadata interface{}) (*LegacyArrayMapping, error) {
+	amapping := &LegacyArrayMapping{}
+	switch t := arrayDatadata.(type) {
+	case string:
+		err := json.Unmarshal([]byte(t), amapping)
+		if err != nil {
+			return nil, err
+		}
+	case interface{}:
+		s, err := coerce.ToString(t)
+		if err != nil {
+			return nil, fmt.Errorf("Convert array mapping value to string error, due to [%s]", err.Error())
+		}
+		err = json.Unmarshal([]byte(s), amapping)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return amapping, nil
+}
+
+func ToNewArray(mapping *LegacyArrayMapping) (interface{}, error) {
+	var newMapping interface{}
+	var fieldsMapping map[string]interface{}
+	if mapping.From == "NEWARRAY" {
+		fieldsMappings := make([]interface{}, 1)
+		fieldsMappings[0] = make(map[string]interface{})
+		fieldsMapping = fieldsMappings[0].(map[string]interface{})
+		newMapping = fieldsMappings
+	} else {
+		newMapping = make(map[string]interface{})
+		fieldsMapping = make(map[string]interface{})
+		newMapping.(map[string]interface{})[fmt.Sprintf("@foreach(%s)", mapping.From)] = fieldsMapping
+	}
+
+	var err error
+	for _, field := range mapping.Fields {
+		if field.Type == "foreach" {
+			//Check to see if it is a new array
+			fieldsMapping[ToNewMapto(field.To)], err = ToNewArray(field)
+		} else {
+			fieldsMapping[ToNewMapto(field.To)], err = convertMapperValue(field.From, field.Type)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return newMapping, nil
+}
+
+func ToNewMapto(old string) string {
+	if strings.HasPrefix(old, "$.") || strings.HasPrefix(old, "$$") {
+		return old[2:]
+	}
+	return old
+}
+
+//func ToMaptoObject(mapto string) (interface{}, error) {
+//	m := make(map[string]interface{})
+//	err := path.SetValue(m, mapto, m)
+//	if err != nil {
+//		return nil, fmt.Errorf("construct object from map to [%s] failed, due to [%s]", mapto, err.Error())
+//	}
+//	return m, nil
+//}
 
 // ToString coerce a value to a string
 func toString(val interface{}) (string, error) {
@@ -94,4 +301,207 @@ func toString(val interface{}) (string, error) {
 	default:
 		return "", nil
 	}
+}
+
+func convertMapperValue(value interface{}, typ string) (interface{}, error) {
+	switch typ {
+	case "assign", "1":
+		if v, ok := value.(string); ok {
+			if !ResolvableExpr(v) {
+				return v, nil
+			}
+			return "=" + v, nil
+		}
+		return value, nil
+	case "literal", "2":
+		return value, nil
+	case "expression", "3":
+		expr, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid expression mapping: '%v'", value)
+		}
+		return "=" + expr, nil
+	case "object", "4":
+		return value, nil
+	case "array", "5":
+		arrayMapping, err := ParseArrayMapping(value)
+		if err != nil {
+			return nil, err
+		}
+		return ToNewArray(arrayMapping)
+	case "primitive":
+		//This use to handle very old array mapping type
+		if priValue, ok := value.(string); ok {
+			if !ResolvableExpr(priValue) {
+				//Not an expr, just return is as value
+				return priValue, nil
+			}
+			return "=" + priValue, nil
+		}
+
+		return value, nil
+	default:
+		return 0, errors.New("unsupported mapping type: " + typ)
+	}
+}
+
+func ResolvableExpr(expr string) bool {
+	_, err := testExprfactory.NewExpr(expr)
+	if err != nil {
+		//Not an expr, just return is as value
+		return false
+	}
+	return true
+}
+
+type MappingField struct {
+	fields []string
+	ref    string
+	s      *scanner.Scanner
+}
+
+func NewMappingField(fields []string) *MappingField {
+	return &MappingField{fields: fields}
+}
+
+func ParseMappingField(mRef string) (*MappingField, error) {
+	//Remove any . at beginning
+	if strings.HasPrefix(mRef, ".") {
+		mRef = mRef[1:]
+	}
+	g := &MappingField{ref: mRef}
+
+	err := g.Start(mRef)
+	if err != nil {
+		return nil, fmt.Errorf("parse mapping [%s] failed, due to %s", mRef, err.Error())
+	}
+	return g, nil
+}
+
+func (m *MappingField) GetRef() string {
+	return m.ref
+}
+
+func (m *MappingField) Getfields() []string {
+	return m.fields
+}
+
+func (m *MappingField) paserName() error {
+	fieldName := ""
+	switch ch := m.s.Scan(); ch {
+	case '.':
+		return m.Parser()
+	case '[':
+		//Done
+		if fieldName != "" {
+			m.fields = append(m.fields, fieldName)
+		}
+		m.s.Mode = scanner.ScanInts
+		nextAfterBracket := m.s.Scan()
+		if nextAfterBracket == '"' || nextAfterBracket == '\'' {
+			//Special charactors
+			m.s.Mode = scanner.ScanIdents
+			return m.handleSpecialField(nextAfterBracket)
+		} else {
+			//HandleArray
+			if m.fields == nil || len(m.fields) <= 0 {
+				m.fields = append(m.fields, "["+m.s.TokenText()+"]")
+			} else {
+				m.fields[len(m.fields)-1] = m.fields[len(m.fields)-1] + "[" + m.s.TokenText() + "]"
+			}
+			ch := m.s.Scan()
+			if ch != ']' {
+				return fmt.Errorf("Inliad array format")
+			}
+			m.s.Mode = scanner.ScanIdents
+			return m.Parser()
+		}
+	case scanner.EOF:
+		if fieldName != "" {
+			m.fields = append(m.fields, fieldName)
+		}
+	default:
+		fieldName = fieldName + m.s.TokenText()
+		if fieldName != "" {
+			m.fields = append(m.fields, fieldName)
+		}
+		return m.Parser()
+	}
+
+	return nil
+}
+
+func (m *MappingField) handleSpecialField(startQutoes int32) error {
+	fieldName := ""
+	run := true
+
+	for run {
+		switch ch := m.s.Scan(); ch {
+		case startQutoes:
+			//Check if end with startQutoes]
+			nextAfterQuotes := m.s.Scan()
+			if nextAfterQuotes == ']' {
+				//end specialfield, startover
+				m.fields = append(m.fields, fieldName)
+				run = false
+				return m.Parser()
+			} else {
+				fieldName = fieldName + string(startQutoes)
+				fieldName = fieldName + m.s.TokenText()
+			}
+		default:
+			fieldName = fieldName + m.s.TokenText()
+		}
+	}
+	return nil
+}
+
+func (m *MappingField) Parser() error {
+	switch ch := m.s.Scan(); ch {
+	case '.':
+		return m.paserName()
+	case '[':
+		m.s.Mode = scanner.ScanInts
+		nextAfterBracket := m.s.Scan()
+		if nextAfterBracket == '"' || nextAfterBracket == '\'' {
+			//Special charactors
+			m.s.Mode = scanner.ScanIdents
+			return m.handleSpecialField(nextAfterBracket)
+		} else {
+			//HandleArray
+			if m.fields == nil || len(m.fields) <= 0 {
+				m.fields = append(m.fields, "["+m.s.TokenText()+"]")
+			} else {
+				m.fields[len(m.fields)-1] = m.fields[len(m.fields)-1] + "[" + m.s.TokenText() + "]"
+			}
+			//m.handleArray()
+			ch := m.s.Scan()
+			if ch != ']' {
+				return fmt.Errorf("Inliad array format")
+			}
+			m.s.Mode = scanner.ScanIdents
+			return m.Parser()
+		}
+	case scanner.EOF:
+		//Done
+		return nil
+	default:
+		m.fields = append(m.fields, m.s.TokenText())
+		return m.paserName()
+	}
+	return nil
+}
+
+func (m *MappingField) Start(jsonPath string) error {
+	m.s = new(scanner.Scanner)
+	m.s.IsIdentRune = IsIdentRune
+	m.s.Init(strings.NewReader(jsonPath))
+	m.s.Mode = scanner.ScanIdents
+	//Donot skip space and new line
+	m.s.Whitespace ^= 1<<'\t' | 1<<'\n' | 1<<'\r' | 1<<' '
+	return m.Parser()
+}
+
+func IsIdentRune(ch rune, i int) bool {
+	return ch == '$' || ch == '-' || ch == '_' || unicode.IsLetter(ch) || unicode.IsDigit(ch) && i > 0
 }

--- a/data/mapper/deprecated_test.go
+++ b/data/mapper/deprecated_test.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/project-flogo/core/data/resolve"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -58,7 +59,7 @@ func TestArrayMapper(t *testing.T) {
 	array, err := ParseArrayMapping(oldArray)
 	assert.Nil(t, err)
 
-	v, err := ToNewArray(array)
+	v, err := ToNewArray(array, resolve.GetBasicResolver())
 	assert.Nil(t, err)
 
 	vv, _ := json.Marshal(v)
@@ -116,7 +117,7 @@ func TestNewArrayMapper(t *testing.T) {
 	array, err := ParseArrayMapping(oldArray)
 	assert.Nil(t, err)
 
-	v, err := ToNewArray(array)
+	v, err := ToNewArray(array, resolve.GetBasicResolver())
 	assert.Nil(t, err)
 
 	vv, _ := json.Marshal(v)
@@ -224,7 +225,7 @@ func TestConvertMappingValue(t *testing.T) {
 	err := json.Unmarshal([]byte(mappings), mapping)
 	assert.Nil(t, err)
 
-	input, output, err := ConvertLegacyMappings(mapping)
+	input, output, err := ConvertLegacyMappings(mapping, resolve.GetBasicResolver())
 	assert.Nil(t, err)
 
 	v, _ := json.Marshal(input)
@@ -270,7 +271,7 @@ func TestConvertMappingValue2(t *testing.T) {
 	err := json.Unmarshal([]byte(mappings), mapping)
 	assert.Nil(t, err)
 
-	input, output, err := ConvertLegacyMappings(mapping)
+	input, output, err := ConvertLegacyMappings(mapping, resolve.GetBasicResolver())
 	assert.Nil(t, err)
 
 	v, _ := json.Marshal(input)
@@ -322,7 +323,7 @@ func TestConvertMappingValue3(t *testing.T) {
 	err := json.Unmarshal([]byte(mappings), mapping)
 	assert.Nil(t, err)
 
-	input, output, err := ConvertLegacyMappings(mapping)
+	input, output, err := ConvertLegacyMappings(mapping, resolve.GetBasicResolver())
 	assert.Nil(t, err)
 
 	v, _ := json.Marshal(input)
@@ -361,7 +362,7 @@ func TestConvertMappingValue4(t *testing.T) {
 	err := json.Unmarshal([]byte(mappings), mapping)
 	assert.Nil(t, err)
 
-	input, output, err := ConvertLegacyMappings(mapping)
+	input, output, err := ConvertLegacyMappings(mapping, resolve.GetBasicResolver())
 	assert.Nil(t, err)
 
 	v, _ := json.Marshal(input)
@@ -416,7 +417,7 @@ func TestConvertMappingWithObjectMapping(t *testing.T) {
 	err := json.Unmarshal([]byte(mappings), mapping)
 	assert.Nil(t, err)
 
-	input, output, err := ConvertLegacyMappings(mapping)
+	input, output, err := ConvertLegacyMappings(mapping, resolve.GetBasicResolver())
 	assert.Nil(t, err)
 
 	v, _ := json.Marshal(input)

--- a/data/mapper/deprecated_test.go
+++ b/data/mapper/deprecated_test.go
@@ -127,7 +127,7 @@ func TestPathToObject(t *testing.T) {
 	path := []string{"data", "field", "value"}
 	obj := make(map[string]interface{})
 
-	toObjectFromPath(path, "1234", obj)
+	constructObjectFromPath(path, "1234", obj)
 	v, _ := json.Marshal(obj)
 	fmt.Println(string(v))
 	assert.Equal(t, "1234", obj["data"].(map[string]interface{})["field"].(map[string]interface{})["value"])
@@ -137,7 +137,7 @@ func TestPathToObjectArray(t *testing.T) {
 	path := []string{"data[2]", "field[0]", "value"}
 	obj := make(map[string]interface{})
 
-	toObjectFromPath(path, "1234", obj)
+	constructObjectFromPath(path, "1234", obj)
 	v, _ := json.Marshal(obj)
 	fmt.Println(string(v))
 	assert.Equal(t, "1234", obj["data"].([]interface{})[2].(map[string]interface{})["field"].([]interface{})[0].(map[string]interface{})["value"])
@@ -150,9 +150,9 @@ func TestMultiplePathToObject(t *testing.T) {
 
 	obj := make(map[string]interface{})
 
-	toObjectFromPath(path, "1234", obj)
+	constructObjectFromPath(path, "1234", obj)
 
-	toObjectFromPath(path2, "1234", obj)
+	constructObjectFromPath(path2, "1234", obj)
 
 	v, _ := json.Marshal(obj)
 	fmt.Println(string(v))
@@ -164,13 +164,15 @@ func TestMultiplePathToObjectArray(t *testing.T) {
 	obj := make(map[string]interface{})
 	path2 := []string{"data[4]", "field[0]", "value"}
 
-	toObjectFromPath(path, "1234", obj)
+	constructObjectFromPath(path, "1234", obj)
 
-	toObjectFromPath(path2, "1234", obj)
+	constructObjectFromPath(path2, "1234", obj)
 
 	v, _ := json.Marshal(obj)
 	fmt.Println(string(v))
 	assert.Equal(t, "1234", obj["data"].([]interface{})[2].(map[string]interface{})["field"].([]interface{})[0].(map[string]interface{})["value"])
+	assert.Equal(t, "1234", obj["data"].([]interface{})[4].(map[string]interface{})["field"].([]interface{})[0].(map[string]interface{})["value"])
+
 }
 
 func TestMultiplePathToObjectArray2(t *testing.T) {
@@ -178,11 +180,256 @@ func TestMultiplePathToObjectArray2(t *testing.T) {
 	obj := make(map[string]interface{})
 	path2 := []string{"data", "field", "value[4]"}
 
-	toObjectFromPath(path, 22, obj)
+	constructObjectFromPath(path, 22, obj)
 
-	toObjectFromPath(path2, 33, obj)
+	constructObjectFromPath(path2, 33, obj)
 
 	v, _ := json.Marshal(obj)
 	fmt.Println(string(v))
-	assert.Equal(t, "1234", obj["data"].([]interface{})[2].(map[string]interface{})["field"].([]interface{})[0].(map[string]interface{})["value"])
+	assert.Equal(t, 22, obj["data"].(map[string]interface{})["field"].(map[string]interface{})["value"].([]interface{})[0])
+	assert.Equal(t, 33, obj["data"].(map[string]interface{})["field"].(map[string]interface{})["value"].([]interface{})[4])
+
+}
+
+func TestConvertMappingValue(t *testing.T) {
+	mappings := `{
+        "input": [
+         {
+          "mapTo": "input1",
+          "type": "expression",
+          "value": "$.body.id"
+         },
+         {
+          "mapTo": "input2",
+          "type": "expression",
+          "value": "$.body.name"
+         }
+        ],
+        "output": [
+         {
+          "mapTo": "code",
+          "type": "expression",
+          "value": 200
+         },
+         {
+          "mapTo": "data.return",
+          "type": "expression",
+          "value": "$.res"
+         }
+        ]
+       }`
+
+	mapping := &LegacyMappings{}
+
+	err := json.Unmarshal([]byte(mappings), mapping)
+	assert.Nil(t, err)
+
+	input, output, err := ConvertLegacyMappings(mapping)
+	assert.Nil(t, err)
+
+	v, _ := json.Marshal(input)
+	fmt.Println("input:", string(v))
+
+	v2, _ := json.Marshal(output)
+	fmt.Println("output:", string(v2))
+	assert.Equal(t, "=$.body.id", input["input1"])
+	assert.Equal(t, "=$.body.name", input["input2"])
+
+}
+
+func TestConvertMappingValue2(t *testing.T) {
+	mappings := `{
+        "input": [
+         {
+          "mapTo": "input1.a.b",
+          "type": "expression",
+          "value": "$.body.id"
+         },
+         {
+          "mapTo": "input1.a.c",
+          "type": "expression",
+          "value": "$.body.name"
+         }
+        ],
+        "output": [
+         {
+          "mapTo": "code",
+          "type": "expression",
+          "value": 200
+         },
+         {
+          "mapTo": "data.return",
+          "type": "expression",
+          "value": "$.res"
+         }
+        ]
+       }`
+
+	mapping := &LegacyMappings{}
+
+	err := json.Unmarshal([]byte(mappings), mapping)
+	assert.Nil(t, err)
+
+	input, output, err := ConvertLegacyMappings(mapping)
+	assert.Nil(t, err)
+
+	v, _ := json.Marshal(input)
+	fmt.Println("input:", string(v))
+
+	v2, _ := json.Marshal(output)
+	fmt.Println("output:", string(v2))
+
+	assert.Equal(t, "=$.body.id", input["input1"].(map[string]interface{})["a"].(map[string]interface{})["b"])
+	assert.Equal(t, "=$.body.name", input["input1"].(map[string]interface{})["a"].(map[string]interface{})["c"])
+
+}
+
+func TestConvertMappingValue3(t *testing.T) {
+	mappings := `{
+        "input": [
+         {
+          "mapTo": "input1[0].a.b",
+          "type": "expression",
+          "value": "$.body.id"
+         },
+         {
+          "mapTo": "data[0]",
+          "type": "expression",
+          "value": "$.body.name"
+         },
+		{
+          "mapTo": "data[1]",
+          "type": "expression",
+          "value": "$.body.name"
+         }
+        ],
+        "output": [
+         {
+          "mapTo": "code",
+          "type": "expression",
+          "value": 200
+         },
+         {
+          "mapTo": "data.return",
+          "type": "expression",
+          "value": "$.res"
+         }
+        ]
+       }`
+
+	mapping := &LegacyMappings{}
+
+	err := json.Unmarshal([]byte(mappings), mapping)
+	assert.Nil(t, err)
+
+	input, output, err := ConvertLegacyMappings(mapping)
+	assert.Nil(t, err)
+
+	v, _ := json.Marshal(input)
+	fmt.Println("input:", string(v))
+
+	v2, _ := json.Marshal(output)
+	fmt.Println("output:", string(v2))
+	assert.Equal(t, "=$.body.name", input["data"].([]interface{})[0])
+	assert.Equal(t, "=$.body.name", input["data"].([]interface{})[1])
+	assert.Equal(t, "=$.body.id", input["input1"].([]interface{})[0].(map[string]interface{})["a"].(map[string]interface{})["b"])
+
+	//output
+	assert.Equal(t, "=$.res", output["data"].(map[string]interface{})["return"])
+	assert.Equal(t, float64(200), output["code"])
+
+}
+
+func TestConvertMappingValue4(t *testing.T) {
+	mappings := `{
+        "input": [
+         {
+          "mapTo": "data[0]",
+          "type": "expression",
+          "value": "$.body.name"
+         },
+		{
+          "mapTo": "data[1]",
+          "type": "expression",
+          "value": "$.body.ddd"
+         }
+        ]
+       }`
+
+	mapping := &LegacyMappings{}
+
+	err := json.Unmarshal([]byte(mappings), mapping)
+	assert.Nil(t, err)
+
+	input, output, err := ConvertLegacyMappings(mapping)
+	assert.Nil(t, err)
+
+	v, _ := json.Marshal(input)
+	fmt.Println("input:", string(v))
+
+	v2, _ := json.Marshal(output)
+	fmt.Println("output:", string(v2))
+	assert.Equal(t, "=$.body.name", input["data"].([]interface{})[0])
+	assert.Equal(t, "=$.body.ddd", input["data"].([]interface{})[1])
+}
+
+func TestConvertMappingWithObjectMapping(t *testing.T) {
+	mappings := `{
+        "input": [
+         {
+          "mapTo": "input1[0].a.b",
+          "type": "expression",
+          "value": "$.body.id"
+         },
+		 {
+				"mapto":"input1[1].a",
+				"type":"array",
+				"value":"{\r\n    \"fields\": [\r\n        {\r\n            \"from\": \"tstring.concat(\\\"this street name: \\\", \\\"ddd\\\")\",\r\n            \"to\": \"$.street\",\r\n            \"type\": \"primitive\"\r\n        },\r\n        {\r\n            \"from\": \"tstring.concat(\\\"The zipcode is: \\\",$.zipcode)\",\r\n            \"to\": \"$.zipcode\",\r\n            \"type\": \"primitive\"\r\n        },\r\n        {\r\n            \"from\": \"$.state\",\r\n            \"to\": \"$.state\",\r\n            \"type\": \"primitive\"\r\n        },\r\n\t\t{\r\n    \t\t\"from\": \"$.array\",\r\n    \t\t\"to\": \"$.array\",\r\n            \"type\": \"foreach\",\r\n\t\t\t\"fields\":[\r\n\t\t\t\t{\r\n           \t\t\t \"from\": \"$.field1\",\r\n           \t\t\t \"to\": \"$.tofield1\",\r\n           \t\t\t \"type\": \"assign\"\r\n        \t\t},\r\n\t\t\t\t{\r\n            \t\t\"from\": \"$.field2\",\r\n\t\t\t\t\t\"to\": \"$.tofield2\",\r\n            \t\t\"type\": \"assign\"\r\n        \t\t},\r\n\t\t\t\t{\r\n            \t\t\"from\": \"wangzai\",\r\n\t\t\t\t\t\"to\": \"$.tofield3\",\r\n            \t\t\"type\": \"assign\"\r\n        \t\t}\r\n\t\t\t]\r\n\r\n\t\t}\r\n    ],\r\n    \"from\": \"$activity[a1].field.addresses\",\r\n    \"to\": \".field.addresses\",\r\n    \"type\": \"foreach\"\r\n}"
+         },
+         {
+          "mapTo": "data[0]",
+          "type": "expression",
+          "value": "$.body.name"
+         },
+		{
+          "mapTo": "data[1]",
+          "type": "expression",
+          "value": "$.body.name"
+         }
+        ],
+        "output": [
+         {
+          "mapTo": "code",
+          "type": "expression",
+          "value": 200
+         },
+         {
+          "mapTo": "data.return",
+          "type": "expression",
+          "value": "$.res"
+         }
+        ]
+       }`
+
+	mapping := &LegacyMappings{}
+
+	err := json.Unmarshal([]byte(mappings), mapping)
+	assert.Nil(t, err)
+
+	input, output, err := ConvertLegacyMappings(mapping)
+	assert.Nil(t, err)
+
+	v, _ := json.Marshal(input)
+	fmt.Println("input:", string(v))
+
+	v2, _ := json.Marshal(output)
+	fmt.Println("output:", string(v2))
+	assert.Equal(t, "=$.body.name", input["data"].([]interface{})[0])
+	assert.Equal(t, "=$.body.name", input["data"].([]interface{})[1])
+	assert.Equal(t, "=$.body.id", input["input1"].([]interface{})[0].(map[string]interface{})["a"].(map[string]interface{})["b"])
+
+	//output
+	assert.Equal(t, "=$.res", output["data"].(map[string]interface{})["return"])
+	assert.Equal(t, float64(200), output["code"])
+
 }

--- a/data/mapper/deprecated_test.go
+++ b/data/mapper/deprecated_test.go
@@ -1,0 +1,188 @@
+package mapper
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestArrayMapper(t *testing.T) {
+	oldArray := `{
+    "fields": [
+        {
+            "from": "tstring.concat(\"this street name: \", \"ddd\")",
+            "to": "$.street",
+            "type": "primitive"
+        },
+        {
+            "from": "tstring.concat(\"The zipcode is: \",$.zipcode)",
+            "to": "$.zipcode",
+            "type": "primitive"
+        },
+        {
+            "from": "$.state",
+            "to": "$.state",
+            "type": "primitive"
+        },
+		{
+    		"from": "$.array",
+    		"to": "$.array",
+            "type": "foreach",
+			"fields":[
+				{
+           			 "from": "$.field1",
+           			 "to": "$.tofield1",
+           			 "type": "assign"
+        		},
+				{
+            		"from": "$.field2",
+					"to": "$.tofield2",
+            		"type": "assign"
+        		},
+				{
+            		"from": "wangzai",
+					"to": "$.tofield3",
+            		"type": "assign"
+        		}
+			]
+
+		}
+    ],
+    "from": "$activity[a1].field.addresses",
+    "to": ".field.addresses",
+    "type": "foreach"
+}
+`
+
+	array, err := ParseArrayMapping(oldArray)
+	assert.Nil(t, err)
+
+	v, err := ToNewArray(array)
+	assert.Nil(t, err)
+
+	vv, _ := json.Marshal(v)
+	fmt.Println(string(vv))
+}
+
+func TestNewArrayMapper(t *testing.T) {
+	oldArray := `{
+    "fields": [
+        {
+            "from": "tstring.concat(\"this street name: \", \"ddd\")",
+            "to": "$.street",
+            "type": "primitive"
+        },
+        {
+            "from": "tstring.concat(\"The zipcode is: \",$.zipcode)",
+            "to": "$.zipcode",
+            "type": "primitive"
+        },
+        {
+            "from": "$.state",
+            "to": "$.state",
+            "type": "primitive"
+        },
+		{
+    		"from": "NEWARRAY",
+    		"to": "$.array",
+            "type": "foreach",
+			"fields":[
+				{
+           			 "from": "$.field1",
+           			 "to": "$.tofield1",
+           			 "type": "assign"
+        		},
+				{
+            		"from": "$.field2",
+					"to": "$.tofield2",
+            		"type": "assign"
+        		},
+				{
+            		"from": "wangzai",
+					"to": "$.tofield3",
+            		"type": "assign"
+        		}
+			]
+
+		}
+    ],
+    "from": "NEWARRAY",
+    "to": ".field.addresses",
+    "type": "foreach"
+}
+`
+
+	array, err := ParseArrayMapping(oldArray)
+	assert.Nil(t, err)
+
+	v, err := ToNewArray(array)
+	assert.Nil(t, err)
+
+	vv, _ := json.Marshal(v)
+	fmt.Println(string(vv))
+}
+
+func TestPathToObject(t *testing.T) {
+	path := []string{"data", "field", "value"}
+	obj := make(map[string]interface{})
+
+	toObjectFromPath(path, "1234", obj)
+	v, _ := json.Marshal(obj)
+	fmt.Println(string(v))
+	assert.Equal(t, "1234", obj["data"].(map[string]interface{})["field"].(map[string]interface{})["value"])
+}
+
+func TestPathToObjectArray(t *testing.T) {
+	path := []string{"data[2]", "field[0]", "value"}
+	obj := make(map[string]interface{})
+
+	toObjectFromPath(path, "1234", obj)
+	v, _ := json.Marshal(obj)
+	fmt.Println(string(v))
+	assert.Equal(t, "1234", obj["data"].([]interface{})[2].(map[string]interface{})["field"].([]interface{})[0].(map[string]interface{})["value"])
+}
+
+func TestMultiplePathToObject(t *testing.T) {
+	path := []string{"data", "field", "value"}
+
+	path2 := []string{"data", "field2", "value"}
+
+	obj := make(map[string]interface{})
+
+	toObjectFromPath(path, "1234", obj)
+
+	toObjectFromPath(path2, "1234", obj)
+
+	v, _ := json.Marshal(obj)
+	fmt.Println(string(v))
+	assert.Equal(t, "1234", obj["data"].(map[string]interface{})["field"].(map[string]interface{})["value"])
+}
+
+func TestMultiplePathToObjectArray(t *testing.T) {
+	path := []string{"data[2]", "field[0]", "value"}
+	obj := make(map[string]interface{})
+	path2 := []string{"data[4]", "field[0]", "value"}
+
+	toObjectFromPath(path, "1234", obj)
+
+	toObjectFromPath(path2, "1234", obj)
+
+	v, _ := json.Marshal(obj)
+	fmt.Println(string(v))
+	assert.Equal(t, "1234", obj["data"].([]interface{})[2].(map[string]interface{})["field"].([]interface{})[0].(map[string]interface{})["value"])
+}
+
+func TestMultiplePathToObjectArray2(t *testing.T) {
+	path := []string{"data", "field", "value[0]"}
+	obj := make(map[string]interface{})
+	path2 := []string{"data", "field", "value[4]"}
+
+	toObjectFromPath(path, 22, obj)
+
+	toObjectFromPath(path2, 33, obj)
+
+	v, _ := json.Marshal(obj)
+	fmt.Println(string(v))
+	assert.Equal(t, "1234", obj["data"].([]interface{})[2].(map[string]interface{})["field"].([]interface{})[0].(map[string]interface{})["value"])
+}

--- a/data/mapper/deprecated_test.go
+++ b/data/mapper/deprecated_test.go
@@ -42,7 +42,7 @@ func TestArrayMapper(t *testing.T) {
             		"type": "assign"
         		},
 				{
-            		"from": "wangzai",
+            		"from": "flogo",
 					"to": "$.tofield3",
             		"type": "assign"
         		}
@@ -64,6 +64,13 @@ func TestArrayMapper(t *testing.T) {
 
 	vv, _ := json.Marshal(v)
 	fmt.Println(string(vv))
+
+	assert.Equal(t, "=$.state", v.(map[string]interface{})["@foreach($activity[a1].field.addresses)"].(map[string]interface{})["state"])
+	assert.Equal(t, "=tstring.concat(\"this street name: \", \"ddd\")", v.(map[string]interface{})["@foreach($activity[a1].field.addresses)"].(map[string]interface{})["street"])
+	assert.Equal(t, "=$.field1", v.(map[string]interface{})["@foreach($activity[a1].field.addresses)"].(map[string]interface{})["array"].(map[string]interface{})["@foreach($.array)"].(map[string]interface{})["tofield1"])
+	assert.Equal(t, "=$.field2", v.(map[string]interface{})["@foreach($activity[a1].field.addresses)"].(map[string]interface{})["array"].(map[string]interface{})["@foreach($.array)"].(map[string]interface{})["tofield2"])
+	assert.Equal(t, "flogo", v.(map[string]interface{})["@foreach($activity[a1].field.addresses)"].(map[string]interface{})["array"].(map[string]interface{})["@foreach($.array)"].(map[string]interface{})["tofield3"])
+
 }
 
 func TestNewArrayMapper(t *testing.T) {
@@ -122,6 +129,10 @@ func TestNewArrayMapper(t *testing.T) {
 
 	vv, _ := json.Marshal(v)
 	fmt.Println(string(vv))
+
+	assert.Equal(t, "=$.state", v.([]interface{})[0].(map[string]interface{})["state"])
+	assert.Equal(t, "=tstring.concat(\"this street name: \", \"ddd\")", v.([]interface{})[0].(map[string]interface{})["street"])
+	assert.Equal(t, "=$.field1", v.([]interface{})[0].(map[string]interface{})["array"].([]interface{})[0].(map[string]interface{})["tofield1"])
 }
 
 func TestPathToObject(t *testing.T) {
@@ -374,7 +385,7 @@ func TestConvertMappingValue4(t *testing.T) {
 	assert.Equal(t, "=$.body.ddd", input["data"].([]interface{})[1])
 }
 
-func TestConvertMappingWithObjectMapping(t *testing.T) {
+func TestConvertMappingWithArrayMapping(t *testing.T) {
 	mappings := `{
         "input": [
          {
@@ -383,7 +394,7 @@ func TestConvertMappingWithObjectMapping(t *testing.T) {
           "value": "$.body.id"
          },
 		 {
-				"mapto":"input1[1].a",
+				"mapto":"input1[1].c",
 				"type":"array",
 				"value":"{\r\n    \"fields\": [\r\n        {\r\n            \"from\": \"tstring.concat(\\\"this street name: \\\", \\\"ddd\\\")\",\r\n            \"to\": \"$.street\",\r\n            \"type\": \"primitive\"\r\n        },\r\n        {\r\n            \"from\": \"tstring.concat(\\\"The zipcode is: \\\",$.zipcode)\",\r\n            \"to\": \"$.zipcode\",\r\n            \"type\": \"primitive\"\r\n        },\r\n        {\r\n            \"from\": \"$.state\",\r\n            \"to\": \"$.state\",\r\n            \"type\": \"primitive\"\r\n        },\r\n\t\t{\r\n    \t\t\"from\": \"$.array\",\r\n    \t\t\"to\": \"$.array\",\r\n            \"type\": \"foreach\",\r\n\t\t\t\"fields\":[\r\n\t\t\t\t{\r\n           \t\t\t \"from\": \"$.field1\",\r\n           \t\t\t \"to\": \"$.tofield1\",\r\n           \t\t\t \"type\": \"assign\"\r\n        \t\t},\r\n\t\t\t\t{\r\n            \t\t\"from\": \"$.field2\",\r\n\t\t\t\t\t\"to\": \"$.tofield2\",\r\n            \t\t\"type\": \"assign\"\r\n        \t\t},\r\n\t\t\t\t{\r\n            \t\t\"from\": \"wangzai\",\r\n\t\t\t\t\t\"to\": \"$.tofield3\",\r\n            \t\t\"type\": \"assign\"\r\n        \t\t}\r\n\t\t\t]\r\n\r\n\t\t}\r\n    ],\r\n    \"from\": \"$activity[a1].field.addresses\",\r\n    \"to\": \".field.addresses\",\r\n    \"type\": \"foreach\"\r\n}"
          },
@@ -428,7 +439,7 @@ func TestConvertMappingWithObjectMapping(t *testing.T) {
 	assert.Equal(t, "=$.body.name", input["data"].([]interface{})[0])
 	assert.Equal(t, "=$.body.name", input["data"].([]interface{})[1])
 	assert.Equal(t, "=$.body.id", input["input1"].([]interface{})[0].(map[string]interface{})["a"].(map[string]interface{})["b"])
-
+	assert.Equal(t, "=$.state", input["input1"].([]interface{})[1].(map[string]interface{})["c"].(map[string]interface{})["@foreach($activity[a1].field.addresses)"].(map[string]interface{})["state"])
 	//output
 	assert.Equal(t, "=$.res", output["data"].(map[string]interface{})["return"])
 	assert.Equal(t, float64(200), output["code"])

--- a/trigger/config.go
+++ b/trigger/config.go
@@ -141,7 +141,7 @@ func (ac *ActionConfig) UnmarshalJSON(d []byte) error {
 		}
 	}
 
-	input, output, err := mapper.ConvertLegacyMappings(ser.Mappings)
+	input, output, err := mapper.ConvertLegacyMappings(ser.Mappings, resolve.GetBasicResolver())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[*] Other... Please describe: support legacy mapping
```

**Fixes**: 

**What is the current behavior?**
As we changed the way of handling object mapping.  previous we used multiple mapping to a single field value now we are coming up with object mapper which handle `object` + `array mapping`
**What is the new behavior?**
The PR use to handle old mapper,  to convert old mapping format to new. such as:
1. Convert multiple mapping to single object mapping
```
 "input": [
         {
          "mapTo": "input1.a.b",
          "type": "expression",
          "value": "$.body.id"
         },
         {
          "mapTo": "input1.a.c",
          "type": "expression",
          "value": "$.body.name"
         }
        ]
```
to 
```
{
  "input1": {
    "a": {
      "b": "=$.body.id",
      "c": "=$.body.name"
    }
  }
}
```
Same with array mapping, convert old 
```
{
    "fields": [
        {
            "from": "tstring.concat(\"this street name: \", \"ddd\")",
            "to": "$.street",
            "type": "primitive"
        },
        {
            "from": "tstring.concat(\"The zipcode is: \",$.zipcode)",
            "to": "$.zipcode",
            "type": "primitive"
        },
        {
            "from": "$.state",
            "to": "$.state",
            "type": "primitive"
        },
		{
    		"from": "$.array",
    		"to": "$.array",
            "type": "foreach",
			"fields":[
				{
           			 "from": "$.field1",
           			 "to": "$.tofield1",
           			 "type": "assign"
        		},
				{
            		"from": "$.field2",
					"to": "$.tofield2",
            		"type": "assign"
        		},
				{
            		"from": "flogo",
					"to": "$.tofield3",
            		"type": "assign"
        		}
			]

		}
    ],
    "from": "$activity[a1].field.addresses",
    "to": ".field.addresses",
    "type": "foreach"
}
```
To
```
{
  "@foreach($activity[a1].field.addresses)": {
    "array": {
      "@foreach($.array)": {
        "tofield1": "=$.field1",
        "tofield2": "=$.field2",
        "tofield3": "flogo"
      }
    },
    "state": "=$.state",
    "street": "=tstring.concat(\"this street name: \", \"ddd\")",
    "zipcode": "=tstring.concat(\"The zipcode is: \",$.zipcode)"
  }
}
```