### PR TITLE
Initialization of property resolvers

### DIFF
--- a/app/propertyresolver/env.go
+++ b/app/propertyresolver/env.go
@@ -3,6 +3,7 @@ package propertyresolver
 import (
 	"encoding/json"
 	"github.com/project-flogo/core/data/property"
+	"github.com/project-flogo/core/engine"
 	"os"
 	"strings"
 
@@ -46,7 +47,7 @@ type EnvVariableValueResolver struct {
 }
 
 func (resolver *EnvVariableValueResolver) Name() string {
-	return "env"
+	return engine.PropertyResolverEnv
 }
 
 func (resolver *EnvVariableValueResolver) LookupValue(key string) (interface{}, bool) {

--- a/app/propertyresolver/env.go
+++ b/app/propertyresolver/env.go
@@ -21,7 +21,7 @@ func init() {
 
 	logger := log.RootLogger()
 
-	property.RegisterExternalResolver("env", &EnvVariableValueResolver{})
+	property.RegisterPropertyResolver("env", &EnvVariableValueResolver{})
 
 	mappings := getEnvValue()
 	if mappings != "" {

--- a/app/propertyresolver/env.go
+++ b/app/propertyresolver/env.go
@@ -21,7 +21,7 @@ func init() {
 
 	logger := log.RootLogger()
 
-	property.RegisterPropertyResolver("env", &EnvVariableValueResolver{})
+	property.RegisterPropertyResolver(&EnvVariableValueResolver{})
 
 	mappings := getEnvValue()
 	if mappings != "" {
@@ -43,6 +43,10 @@ func getEnvValue() string {
 
 // Resolve property value from environment variable
 type EnvVariableValueResolver struct {
+}
+
+func (resolver *EnvVariableValueResolver) Name() string {
+	return "env"
 }
 
 func (resolver *EnvVariableValueResolver) LookupValue(key string) (interface{}, bool) {

--- a/app/propertyresolver/json.go
+++ b/app/propertyresolver/json.go
@@ -25,7 +25,7 @@ func init() {
 	filePaths := getExternalFiles()
 	if filePaths != "" {
 		// Register value resolver
-		property.RegisterExternalResolver("json", &JSONFileValueResolver{})
+		property.RegisterPropertyResolver("json", &JSONFileValueResolver{})
 
 		// preload props from files
 		files := strings.Split(filePaths, ",")

--- a/app/propertyresolver/json.go
+++ b/app/propertyresolver/json.go
@@ -3,6 +3,7 @@ package propertyresolver
 import (
 	"encoding/json"
 	"github.com/project-flogo/core/data/property"
+	"github.com/project-flogo/core/engine"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -65,7 +66,7 @@ type JSONFileValueResolver struct {
 }
 
 func (resolver *JSONFileValueResolver) Name() string {
-	return "json"
+	return engine.PropertyResolverJson
 }
 
 func (resolver *JSONFileValueResolver) LookupValue(toResolve string) (interface{}, bool) {

--- a/app/propertyresolver/json.go
+++ b/app/propertyresolver/json.go
@@ -25,7 +25,7 @@ func init() {
 	filePaths := getExternalFiles()
 	if filePaths != "" {
 		// Register value resolver
-		property.RegisterPropertyResolver("json", &JSONFileValueResolver{})
+		property.RegisterPropertyResolver(&JSONFileValueResolver{})
 
 		// preload props from files
 		files := strings.Split(filePaths, ",")
@@ -62,6 +62,10 @@ func getExternalFiles() string {
 
 // Resolve property value from external files
 type JSONFileValueResolver struct {
+}
+
+func (resolver *JSONFileValueResolver) Name() string {
+	return "json"
 }
 
 func (resolver *JSONFileValueResolver) LookupValue(toResolve string) (interface{}, bool) {

--- a/data/property/resolver.go
+++ b/data/property/resolver.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	externalResolverMap = make(map[string]ExternalResolver)
-	externalResolvers   []ExternalResolver
+	RegisteredResolvers = make(map[string]ExternalResolver)
+	EnabledResolvers    []ExternalResolver
 )
 
 // Resolver used to resolve property value from external configuration like env, file etc
@@ -31,30 +31,30 @@ func RegisterExternalResolver(resolverType string, resolver ExternalResolver) er
 		return fmt.Errorf("cannot register 'nil' external property resolver")
 	}
 
-	if _, dup := externalResolverMap[resolverType]; dup {
+	if _, dup := RegisteredResolvers[resolverType]; dup {
 		return fmt.Errorf("external property resolver already registered: %s", resolverType)
 	}
 
 	logger.Debugf("Registering external property resolver [ %s ]", resolverType)
 
-	externalResolverMap[resolverType] = resolver
+	RegisteredResolvers[resolverType] = resolver
 
 	return nil
 }
 
 func GetExternalResolver(resolverType string) ExternalResolver {
-	return externalResolverMap[resolverType]
+	return RegisteredResolvers[resolverType]
 }
 
 func EnableExternalResolvers(resolverTypes string) error {
 
 	for _, resolverType := range strings.Split(resolverTypes, ",") {
-		resolver := externalResolverMap[resolverType]
+		resolver := RegisteredResolvers[resolverType]
 		if resolver == nil {
 			errMag := fmt.Sprintf("Unsupported external property resolver type - %s. Resolver not registered.", resolverType)
 			return errors.New(errMag)
 		}
-		externalResolvers = append(externalResolvers, resolver)
+		EnabledResolvers = append(EnabledResolvers, resolver)
 	}
 
 	return nil
@@ -62,7 +62,7 @@ func EnableExternalResolvers(resolverTypes string) error {
 
 func ResolveExternally(propertyName string) (interface{}, bool) {
 
-	for _, resolver := range externalResolvers {
+	for _, resolver := range EnabledResolvers {
 		// Use resolver
 		value, resolved := resolver.LookupValue(propertyName)
 		if resolved {
@@ -81,7 +81,7 @@ func ExternalPropertyResolverProcessor(properties map[string]interface{}) error 
 		newVal, found := ResolveExternally(name)
 
 		if !found {
-			logger.Warnf("Property '%s' could not be resolved using external resolver(s) '%s'. Using default value.", name)
+			logger.Warnf("Property '%s' could not be resolved using property resolver(s). Using default value from flogo.json.", name)
 		} else {
 			properties[name] = newVal
 		}

--- a/data/property/resolver.go
+++ b/data/property/resolver.go
@@ -9,49 +9,49 @@ import (
 )
 
 var (
-	RegisteredResolvers = make(map[string]ExternalResolver)
-	EnabledResolvers    []ExternalResolver
+	RegisteredResolvers = make(map[string]Resolver)
+	EnabledResolvers    []Resolver
 )
 
 // Resolver used to resolve property value from external configuration like env, file etc
-type ExternalResolver interface {
+type Resolver interface {
 	// Should return value and true if the given key exists in the external configuration otherwise should return nil and false.
 	LookupValue(key string) (interface{}, bool)
 }
 
-func RegisterExternalResolver(resolverType string, resolver ExternalResolver) error {
+func RegisterPropertyResolver(resolverType string, resolver Resolver) error {
 
 	logger := log.RootLogger()
 
 	if resolverType == "" {
-		return fmt.Errorf("'resolverType' must be specified when registering external property resolver")
+		return fmt.Errorf("'resolverType' must be specified when registering a property resolver")
 	}
 
 	if resolver == nil {
-		return fmt.Errorf("cannot register 'nil' external property resolver")
+		return fmt.Errorf("cannot register 'nil' property resolver")
 	}
 
 	if _, dup := RegisteredResolvers[resolverType]; dup {
-		return fmt.Errorf("external property resolver already registered: %s", resolverType)
+		return fmt.Errorf("property resolver already registered: %s", resolverType)
 	}
 
-	logger.Debugf("Registering external property resolver [ %s ]", resolverType)
+	logger.Debugf("Registering property resolver [ %s ]", resolverType)
 
 	RegisteredResolvers[resolverType] = resolver
 
 	return nil
 }
 
-func GetExternalResolver(resolverType string) ExternalResolver {
+func GetPropertyResolver(resolverType string) Resolver {
 	return RegisteredResolvers[resolverType]
 }
 
-func EnableExternalResolvers(resolverTypes string) error {
+func EnablePropertyResolvers(resolverTypes string) error {
 
 	for _, resolverType := range strings.Split(resolverTypes, ",") {
 		resolver := RegisteredResolvers[resolverType]
 		if resolver == nil {
-			errMag := fmt.Sprintf("Unsupported external property resolver type - %s. Resolver not registered.", resolverType)
+			errMag := fmt.Sprintf("Unsupported property resolver type - %s. Resolver not registered.", resolverType)
 			return errors.New(errMag)
 		}
 		EnabledResolvers = append(EnabledResolvers, resolver)
@@ -60,7 +60,7 @@ func EnableExternalResolvers(resolverTypes string) error {
 	return nil
 }
 
-func ResolveExternally(propertyName string) (interface{}, bool) {
+func ResolveProperty(propertyName string) (interface{}, bool) {
 
 	for _, resolver := range EnabledResolvers {
 		// Use resolver
@@ -73,12 +73,12 @@ func ResolveExternally(propertyName string) (interface{}, bool) {
 	return nil, false
 }
 
-func ExternalPropertyResolverProcessor(properties map[string]interface{}) error {
+func PropertyResolverProcessor(properties map[string]interface{}) error {
 
 	logger := log.RootLogger()
 
 	for name := range properties {
-		newVal, found := ResolveExternally(name)
+		newVal, found := ResolveProperty(name)
 
 		if !found {
 			logger.Warnf("Property '%s' could not be resolved using property resolver(s). Using default value from flogo.json.", name)

--- a/engine/config.go
+++ b/engine/config.go
@@ -110,6 +110,9 @@ func displayAppPropertyValueResolversHelp(logger log.Logger, resolvers []string)
 func GetAppPropertyValueResolvers(logger log.Logger) string {
 	key := os.Getenv(EnvAppPropertyResolvers)
 	if len(key) > 0 {
+		if key == "disabled" {
+			return ""
+		}
 		return key
 	}
 

--- a/engine/config.go
+++ b/engine/config.go
@@ -29,6 +29,9 @@ const (
 
 	ValueRunnerTypePooled = "POOLED"
 	ValueRunnerTypeDirect = "DIRECT"
+
+	PropertyResolverEnv  = "env"
+	PropertyResolverJson = "json"
 )
 
 func IsSchemaSupportEnabled() bool {
@@ -120,22 +123,27 @@ func GetAppPropertyValueResolvers(logger log.Logger) string {
 		}
 	case 2, 3:
 		var resolvers, builtinResolvers []string
+
 		for resolver := range property.RegisteredResolvers {
-			if resolver != "env" && resolver != "json" {
+			if resolver != PropertyResolverEnv && resolver != PropertyResolverJson {
 				resolvers = append(resolvers, resolver)
 			} else {
 				builtinResolvers = append(builtinResolvers, resolver)
 			}
 		}
+
 		if len(resolvers) > 1 { // multiple (excluding builtin) resolvers defined, do nothing and hint to enforce an order
 			resolvers = append(resolvers, builtinResolvers...)
 			displayAppPropertyValueResolversHelp(logger, resolvers)
 			return ""
 		}
-		resolvers = append(resolvers, builtinResolvers...)
+
 		if len(builtinResolvers) == 2 { // force priority between the two builtin resolvers
-			builtinResolvers = []string{"env", "json"}
+			builtinResolvers = []string{PropertyResolverEnv, PropertyResolverJson}
 		}
+
+		resolvers = append(resolvers, builtinResolvers...)
+
 		return strings.Join(resolvers[:], ",")
 	default: // multiple (excluding builtin) resolvers defined, do nothing and hint to enforce an order
 		var resolvers []string

--- a/engine/engineimpl.go
+++ b/engine/engineimpl.go
@@ -89,7 +89,7 @@ func New(appConfig *app.Config, options ...Option) (Engine, error) {
 		appOptions = append(appOptions, app.ContinueOnError)
 	}
 
-	propResolvers := GetAppPropertyValueResolvers()
+	propResolvers := GetAppPropertyValueResolvers(logger)
 	enableExternalPropResolution := false
 	if len(propResolvers) > 0 {
 		err := property.EnableExternalResolvers(propResolvers)

--- a/engine/engineimpl.go
+++ b/engine/engineimpl.go
@@ -90,20 +90,20 @@ func New(appConfig *app.Config, options ...Option) (Engine, error) {
 	}
 
 	propResolvers := GetAppPropertyValueResolvers(logger)
-	enableExternalPropResolution := false
+	enablePropertiesResolution := false
 	if len(propResolvers) > 0 {
-		err := property.EnableExternalResolvers(propResolvers)
+		err := property.EnablePropertyResolvers(propResolvers)
 		if err != nil {
 			return nil, err
 		}
 
-		enableExternalPropResolution = true
+		enablePropertiesResolution = true
 	}
 
-	// properties post processors (external properties resolver if enabled, secret property replacer)
+	// properties post processors (properties resolver if enabled, secret properties replacer)
 	var postProcessors []property.PostProcessor
-	if enableExternalPropResolution {
-		postProcessors = append(postProcessors, property.ExternalPropertyResolverProcessor)
+	if enablePropertiesResolution {
+		postProcessors = append(postProcessors, property.PropertyResolverProcessor)
 	}
 	postProcessors = append(postProcessors, secret.PropertyProcessor)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Related to**: #9 

**What is the current behavior?**
Property resolvers are enabled:
1. by importing their package which will register the resolver at engine startup.
2. by setting ```FLOGO_APP_PROP_RESOLVERS``` environment variable with a comma-separated list of resolvers names (for instance ```FLOGO_APP_PROP_RESOLVERS=env,json```)

It exists two "builtin" resolvers (provided by github.com/project-flogo/core) called "env" & "json" and any number of "custom" resolvers can be registered from other contributions.

**Setting an environment variable to enable registered resolvers in simple scenarios is somewhat cumbersome.**

**What is the new behavior?**

The goal of this PR is to **provide convenient default behaviours** to avoid to set the ```FLOGO_APP_PROP_RESOLVERS``` environment variable when it's possible.

Imported property resolvers can be automatically enabled following these rules:

* if only the two builtin resolvers are imported ("env" & "json") then they will be automatically enabled and used in this order. It can still be overridden by setting ```FLOGO_APP_PROP_RESOLVERS``` (choose only one, change order of priority)
* __if only one resolver is imported then it will be automatically enabled__
* if only one resolver and the builtin resolvers are imported then they will be automatically enabled and will use this order of priority *custom* > *env* > *json*. It can still be overridden by setting ```FLOGO_APP_PROP_RESOLVERS``` (choose only one or two, change order of priority)
* if more than two resolvers, with or without the builtin resolvers, are imported then __no property resolver will be enabled__ and __a clear help message will be displayed__ to explain how to set ```FLOGO_APP_PROP_RESOLVERS``` environment variable
* if ```FLOGO_APP_PROP_RESOLVERS==disabled```, no property resolver is enabled and no message is displayed as the environment variable was explicitly set