### PR TITLE
Fix object mapping when second level no foreach

### DIFF
--- a/data/mapper/expr_test.go
+++ b/data/mapper/expr_test.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/project-flogo/core/data"
@@ -259,13 +260,15 @@ func BenchmarkExpressionMapperTernaryExpr(b *testing.B) {
 
 func init() {
 	_ = function.Register(&fnConcat{})
+	function.SetPackageAlias(reflect.ValueOf(fnConcat{}).Type().PkgPath(), "tstring")
+	function.ResolveAliases()
 }
 
 type fnConcat struct {
 }
 
 func (fnConcat) Name() string {
-	return "tstring.concat"
+	return "concat"
 }
 
 func (fnConcat) Sig() (paramTypes []data.Type, isVariadic bool) {

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -2,7 +2,6 @@ package mapper
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/project-flogo/core/data"
 	"github.com/project-flogo/core/data/resolve"
 	"testing"
@@ -605,11 +604,7 @@ func TestLiteral(t *testing.T) {
 	assert.Nil(t, err)
 
 	arr := results["addresses"]
-	v, _ := json.Marshal(arr)
-	fmt.Println(string(v))
-	//assert.Equal(t, "person", arr.(map[string]interface{})["person2"])
-	//assert.Equal(t, float64(77479), arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tozipcode"])
-	//assert.Equal(t, "State is tx", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tostate"])
+	assert.Equal(t, "Earth", arr.(map[string]interface{})["Character"].(map[string]interface{})["homePlanet"])
 
 }
 

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -2,6 +2,7 @@ package mapper
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/project-flogo/core/data"
 	"github.com/project-flogo/core/data/resolve"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 func TestObjectMappingWithFunction(t *testing.T) {
-	mappingValue := `{
+	mappingValue := `{"mapping": {
         "person2" : "person",
         "addresses": {
               "tostate"   : "=tstring.concat(\"State is \", \"tx\")",
@@ -19,7 +20,8 @@ func TestObjectMappingWithFunction(t *testing.T) {
 					"tofield2": "=tstring.concat(\"field is \", \"ffff\")"
               }
         }
-    }`
+    }
+}`
 
 	arrayMapping := make(map[string]interface{})
 	err := json.Unmarshal([]byte(mappingValue), &arrayMapping)
@@ -40,7 +42,7 @@ func TestObjectMappingWithFunction(t *testing.T) {
 }
 
 func TestObjectMappingWithArray(t *testing.T) {
-	mappingValue := `{
+	mappingValue := `{"mapping": {
   "person2": "person",
   "addresses": {
     "array": [
@@ -50,6 +52,7 @@ func TestObjectMappingWithArray(t *testing.T) {
       }
     ]
   }
+}
 }`
 
 	arrayMapping := make(map[string]interface{})
@@ -66,13 +69,13 @@ func TestObjectMappingWithArray(t *testing.T) {
 	arr := results["addresses"]
 
 	assert.Equal(t, "person", arr.(map[string]interface{})["person2"])
-	assert.Equal(t, "ddd is tx", arr.(map[string]interface{})["array"].([]interface{})[0].(map[string]interface{})["ddd"])
-	assert.Equal(t, "ccc is tx", arr.(map[string]interface{})["array"].([]interface{})[0].(map[string]interface{})["ccc"])
+	assert.Equal(t, "ddd is tx", arr.(map[string]interface{})["addresses"].(map[string]interface{})["array"].([]interface{})[0].(map[string]interface{})["ddd"])
+	assert.Equal(t, "ccc is tx", arr.(map[string]interface{})["addresses"].(map[string]interface{})["array"].([]interface{})[0].(map[string]interface{})["ccc"])
 
 }
 
 func TestRootObjectArray(t *testing.T) {
-	mappingValue := `[
+	mappingValue := `{"mapping": [
    {
       "id":"11111",
       "name":"nnnnn",
@@ -83,7 +86,8 @@ func TestRootObjectArray(t *testing.T) {
 			}
       }
    }
-]`
+]
+}`
 
 	arrayData := `{
    "person": "name",
@@ -142,7 +146,7 @@ func TestRootLiteralArray(t *testing.T) {
 }
 
 func TestPrimitiveArray(t *testing.T) {
-	mappingValue := `
+	mappingValue := `{"mapping": 
 {
   "features": [
     {
@@ -155,6 +159,7 @@ func TestPrimitiveArray(t *testing.T) {
       ]
     }
   ]
+}
 }`
 
 	var arrayMapping interface{}
@@ -186,7 +191,7 @@ func TestPrimitiveArray(t *testing.T) {
 }
 
 func TestRootLiteralArrayMapping(t *testing.T) {
-	mappingValue := `["=$.field.name", "=$.field.id"]`
+	mappingValue := `{"mapping": ["=$.field.name", "=$.field.id"]}`
 	arrayData := `{
    "name": "name",
 	"id":"1001",
@@ -223,7 +228,7 @@ func TestRootLiteralArrayMapping(t *testing.T) {
 }
 
 func TestRootLiteralNumberArrayMapping(t *testing.T) {
-	mappingValue := `["=$.field.id2", "=$.field.id"]`
+	mappingValue := `{"mapping": ["=$.field.id2", "=$.field.id"]}`
 	arrayData := `{
 	"id2": 1002,
 	"id":1001,
@@ -261,12 +266,12 @@ func TestRootLiteralNumberArrayMapping(t *testing.T) {
 }
 
 func TestRootArrayMapping(t *testing.T) {
-	mappingValue := `{
+	mappingValue := `{"mapping": {
 			"@foreach($.field.addresses, index)":{
 				"id":"dddddd",
 				"name":"=$.state"
 			}
-   }`
+   }}`
 
 	arrayData := `{
    "person": "name",
@@ -277,7 +282,8 @@ func TestRootArrayMapping(t *testing.T) {
            "state": "tx"
 		}
    ]
-}`
+}
+`
 	var arrayValue interface{}
 	err := json.Unmarshal([]byte(arrayData), &arrayValue)
 	assert.Nil(t, err)
@@ -329,7 +335,7 @@ func TestStringStringMap(t *testing.T) {
 }
 
 func TestArrayMappingWithNest(t *testing.T) {
-	mappingValue := `{
+	mappingValue := `{"mapping": {
         "person2" : "person",
         "addresses": {
             "@foreach($.field.addresses, index)":
@@ -346,7 +352,7 @@ func TestArrayMappingWithNest(t *testing.T) {
               }
             }
         }
-    }`
+    }}`
 
 	arrayData := `{
    "person": "name",
@@ -409,7 +415,7 @@ func TestArrayMappingWithNest(t *testing.T) {
 }
 
 func TestArrayMappingWithFunction(t *testing.T) {
-	mappingValue := `{
+	mappingValue := `{"mapping": {
         "person2" : "person",
         "addresses": {
             "@foreach($.field.addresses, index)":
@@ -426,7 +432,8 @@ func TestArrayMappingWithFunction(t *testing.T) {
               }
             }
         }
-    }`
+    }
+}`
 
 	arrayData := `{
    "person": "name",
@@ -472,7 +479,7 @@ func TestArrayMappingWithFunction(t *testing.T) {
 }
 
 func TestArrayMappingWithFunction3Level(t *testing.T) {
-	mappingValue := `{
+	mappingValue := `{"mapping": {
    "person2":"person",
    "addresses":{
       "@foreach($.field.addresses, index)":{
@@ -494,6 +501,7 @@ func TestArrayMappingWithFunction3Level(t *testing.T) {
          }
       }
    }
+}
 }`
 
 	arrayData := `{
@@ -548,6 +556,61 @@ func TestArrayMappingWithFunction3Level(t *testing.T) {
 	assert.Equal(t, "person", arr.(map[string]interface{})["person2"])
 	assert.Equal(t, float64(77479), arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tozipcode"])
 	assert.Equal(t, "State is tx", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tostate"])
+}
+
+func TestLiteral(t *testing.T) {
+	mappingValue := `{"mapping": {
+                      "Character": {
+                        "appearsIn": [
+                          "EMPIRE",
+                          "JEDI"
+                        ],
+                        "friends": [
+                          {
+                            "appearsIn": [
+                              "JEDI"
+                            ],
+                            "friends": [],
+                            "id": "d123",
+                            "name": "r2-d2",
+                            "primaryFunction": "robot"
+                          },
+                          {
+                            "appearsIn": [
+                              "JEDI",
+                              "NEWHOPE"
+                            ],
+                            "friends": [],
+                            "homePlanet": "Mars",
+                            "id": "h234",
+                            "name": "Robert"
+                          }
+                        ],
+                        "homePlanet": "Earth",
+                        "id": "h123",
+                        "name": "Luke"
+                      }
+                    }}`
+
+	arrayMapping := make(map[string]interface{})
+	err := json.Unmarshal([]byte(mappingValue), &arrayMapping)
+	assert.Nil(t, err)
+
+	mappings := map[string]interface{}{"addresses": arrayMapping}
+	factory := NewFactory(resolve.GetBasicResolver())
+	mapper, err := factory.NewMapper(mappings)
+	assert.Nil(t, err)
+
+	results, err := mapper.Apply(nil)
+	assert.Nil(t, err)
+
+	arr := results["addresses"]
+	v, _ := json.Marshal(arr)
+	fmt.Println(string(v))
+	//assert.Equal(t, "person", arr.(map[string]interface{})["person2"])
+	//assert.Equal(t, float64(77479), arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tozipcode"])
+	//assert.Equal(t, "State is tx", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tostate"])
+
 }
 
 func TestGetSource(t *testing.T) {


### PR DESCRIPTION


**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
There have some mix-up issues while no foreach(arraymapping) at the second level 
**What is the new behavior?**
