### PR TITLE
IsResolveExpr should return false for expressions

### DIFF
--- a/data/resolve/resolve.go
+++ b/data/resolve/resolve.go
@@ -168,7 +168,7 @@ func IsResolveExpr(exprStr string) bool {
 			switch c := exprStr[i]; c {
 			case ' ':
 				return false
-			case '[', '(', '"', '\'', '`':
+			case '[', '"', '\'', '`':
 				end := ends[c]
 				i++
 				for i < len(exprStr) {
@@ -181,6 +181,10 @@ func IsResolveExpr(exprStr string) bool {
 				if i+1 >= strLen || !isLetter(exprStr[i+1]) {
 					return false
 				}
+
+			case '(', '=', '>', '<', '*', '/', '!', '&', '%', '+', '-', '|', '?', ':', '$':
+				//condition expression, tenray expression, array indexer expression
+				return false
 			}
 
 		}

--- a/data/resolve/resolve.go
+++ b/data/resolve/resolve.go
@@ -168,11 +168,25 @@ func IsResolveExpr(exprStr string) bool {
 			switch c := exprStr[i]; c {
 			case ' ':
 				return false
-			case '[', '"', '\'', '`':
+			case '"', '\'', '`':
 				end := ends[c]
 				i++
 				for i < len(exprStr) {
 					if exprStr[i] == end {
+						break
+					}
+					i++
+				}
+			case '[':
+				end := ends[c]
+				i++
+				j := i
+				for i < len(exprStr) {
+					if exprStr[i] == end {
+						//Checking whether value insde [] is expr
+						if hasExprChar(exprStr[j:i]) {
+							return false
+						}
 						break
 					}
 					i++
@@ -182,9 +196,10 @@ func IsResolveExpr(exprStr string) bool {
 					return false
 				}
 
-			case '(', '=', '>', '<', '*', '/', '!', '&', '%', '+', '-', '|', '?', ':', '$':
-				//condition expression, tenray expression, array indexer expression
-				return false
+			default:
+				if isExprChar(c) {
+					return false
+				}
 			}
 
 		}
@@ -193,4 +208,31 @@ func IsResolveExpr(exprStr string) bool {
 	}
 
 	return true
+}
+
+func hasExprChar(str string) bool {
+	//condition expression, tenray expression, array indexer expression
+	if len(str) > 0 {
+		//String
+		if str[0] == '"' || str[0] == '\'' || str[0] == '`' {
+			return false
+		} else {
+			strLen := len(str)
+			for i := 0; i < strLen; i++ {
+				if isExprChar(str[i]) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func isExprChar(ch byte) bool {
+	//condition expression, tenray expression, array indexer expression
+	switch ch {
+	case '(', '=', '>', '<', '*', '/', '!', '&', '%', '+', '-', '|', '?', ':', '$':
+		return true
+	}
+	return false
 }

--- a/data/resolve/resolve_test.go
+++ b/data/resolve/resolve_test.go
@@ -133,3 +133,26 @@ func TestIsResolveExpr(t *testing.T) {
 	isResolve = IsResolveExpr(str)
 	assert.False(t, isResolve)
 }
+
+func TestIsResolveExprWithExpr(t *testing.T) {
+	str := "$activity[REST].id"
+	isResolve := IsResolveExpr(str)
+	assert.True(t, isResolve)
+
+	str = "$activity[REST].id==1"
+	isResolve = IsResolveExpr(str)
+	assert.False(t, isResolve)
+
+	str = "$activity[REST][\"123\"]"
+	isResolve = IsResolveExpr(str)
+	assert.True(t, isResolve)
+
+	str = "$activity[REST].[\"123\"][$.index]"
+	isResolve = IsResolveExpr(str)
+	assert.False(t, isResolve)
+
+	str = "$activity[REST].abc ? $.ok: $.false"
+	isResolve = IsResolveExpr(str)
+	assert.False(t, isResolve)
+
+}

--- a/data/resolve/resolve_test.go
+++ b/data/resolve/resolve_test.go
@@ -147,7 +147,11 @@ func TestIsResolveExprWithExpr(t *testing.T) {
 	isResolve = IsResolveExpr(str)
 	assert.True(t, isResolve)
 
-	str = "$activity[REST].[\"123\"][$.index]"
+	str = "$activity[REST][\"123\"][$.index]"
+	isResolve = IsResolveExpr(str)
+	assert.False(t, isResolve)
+
+	str = "$.body.addresses[$.index]"
 	isResolve = IsResolveExpr(str)
 	assert.False(t, isResolve)
 


### PR DESCRIPTION


**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
IsResolveExpr returns true for expression which does not have space such as `$activity[acb].id==1`
**What is the new behavior?**
IsResolveExpr should return false for condition expression, ternary expression and indexer Expr