### PR TITLE
Access current loop use $loop

### DIFF
--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -81,7 +81,7 @@ func TestRootObjectArray(t *testing.T) {
       "addresses": {
 			"@foreach($.field.addresses, index)":{
 				"id":"dddddd",
-				"name":"=$.state"
+				"name":"=$loop.state"
 			}
       }
    }

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -268,7 +268,7 @@ func TestRootArrayMapping(t *testing.T) {
 	mappingValue := `{"mapping": {
 			"@foreach($.field.addresses, index)":{
 				"id":"dddddd",
-				"name":"=$.state"
+				"name":"=$loop.state"
 			}
    }}`
 
@@ -340,13 +340,13 @@ func TestArrayMappingWithNest(t *testing.T) {
             "@foreach($.field.addresses, index)":
             {
               "tostate"   : "=$loop[index].state",
-               "tostreet": "=$.street",
-               "tozipcode":"=$.zipcode",
+               "tostreet": "=$loop.street",
+               "tozipcode":"=$loop.zipcode",
               "addresses2": {
-                  "@foreach($.array)":{
+                  "@foreach($loop.array)":{
                         "tofield1"  : "=$loop[index].street",
-               			"tofield2": "=$.field2",
-               			"tofield3":"=$.field3"
+               			"tofield2": "=$loop.field2",
+               			"tofield3":"=$loop.field3"
                   }
               }
             }
@@ -420,13 +420,13 @@ func TestArrayMappingWithFunction(t *testing.T) {
             "@foreach($.field.addresses, index)":
             {
               "tostate"   : "=tstring.concat(\"State is \", $loop[index].state)",
-               "tostreet": "=$.street",
-               "tozipcode":"=$.zipcode",
+               "tostreet": "=$loop.street",
+               "tozipcode":"=$loop.zipcode",
               "addresses2": {
-                  "@foreach($.array)":{
+                  "@foreach($loop.array)":{
                         "tofield1"  : "=$loop[index].street",
-               			"tofield2": "=tstring.concat(\"field is \", $.field2)",
-               			"tofield3":"=$.field3"
+               			"tofield2": "=tstring.concat(\"field is \", $loop.field2)",
+               			"tofield3":"=$loop.field3"
                   }
               }
             }
@@ -483,17 +483,17 @@ func TestArrayMappingWithFunction3Level(t *testing.T) {
    "addresses":{
       "@foreach($.field.addresses, index)":{
          "tostate":"=tstring.concat(\"State is \", $loop[index].state)",
-         "tostreet":"=$.street",
-         "tozipcode":"=$.zipcode",
+         "tostreet":"=$loop.street",
+         "tozipcode":"=$loop.zipcode",
          "addresses2":{
-            "@foreach($.array, index2)":{
+            "@foreach($loop.array, index2)":{
                "tofield1":"=$loop[index].street",
-               "tofield2":"=tstring.concat(\"field is \", $.field2)",
-               "tofield3":"=$.field3",
+               "tofield2":"=tstring.concat(\"field is \", $loop.field2)",
+               "tofield3":"=$loop.field3",
                "addresses4":{
-                  "@foreach($.level3)":{
+                  "@foreach($loop.level3)":{
                      "level3":"=$loop[index2].field1",
-                     "level3-1":"=tstring.concat(\"field is \", $.field3)"
+                     "level3-1":"=tstring.concat(\"field is \", $loop.field3)"
                   }
                }
             }

--- a/data/resolve/composite.go
+++ b/data/resolve/composite.go
@@ -83,7 +83,7 @@ func (r *basicResolver) Resolve(directive string, scope data.Scope) (value inter
 		return nil, fmt.Errorf("unable to find a '%s' resolver", resolverName)
 	}
 
-	details, err := GetResolveDirectiveDetails(directive[nextIdx:], resolver.GetResolverInfo().UsesItemFormat())
+	details, err := GetResolveDirectiveDetails(directive[nextIdx:], resolver.GetResolverInfo().UsesItemFormat(), resolver.GetResolverInfo().IsImplicit())
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (r *basicResolver) GetResolution(directive string) (Resolution, error) {
 		return nil, fmt.Errorf("unable to find a '%s' resolver", resolverName)
 	}
 
-	details, err := GetResolveDirectiveDetails(directive[nextIdx:], resolver.GetResolverInfo().UsesItemFormat())
+	details, err := GetResolveDirectiveDetails(directive[nextIdx:], resolver.GetResolverInfo().UsesItemFormat(), resolver.GetResolverInfo().IsImplicit())
 	if err != nil {
 		return nil, err
 	}

--- a/data/resolve/loop.go
+++ b/data/resolve/loop.go
@@ -6,7 +6,7 @@ import (
 	"github.com/project-flogo/core/data/path"
 )
 
-var loopResolverInfo = NewResolverInfo(false, true)
+var loopResolverInfo = NewImplicitResolverInfo(false, true)
 
 type LoopResolver struct {
 }
@@ -17,9 +17,17 @@ func (*LoopResolver) GetResolverInfo() *ResolverInfo {
 
 //LoopResolver Loop Resolver $Loop[item]
 func (*LoopResolver) Resolve(scope data.Scope, item string, field string) (interface{}, error) {
-	value, exists := scope.GetValue(item)
-	if !exists {
-		return nil, fmt.Errorf("failed to resolve Loop: '%s', ensure that Loop is configured in the application", item)
+	if item == "" {
+		v, exist := scope.GetValue(field)
+		if !exist {
+			return nil, fmt.Errorf("failed to resolve current Loop: '%s', ensure that Loop is configured in the application", field)
+		}
+		return v, nil
+	} else {
+		value, exists := scope.GetValue(item)
+		if !exists {
+			return nil, fmt.Errorf("failed to resolve Loop: '%s', ensure that Loop is configured in the application", item)
+		}
+		return path.GetValue(value, "."+field)
 	}
-	return path.GetValue(value, "."+field)
 }

--- a/data/resolve/resolve.go
+++ b/data/resolve/resolve.go
@@ -99,6 +99,7 @@ func GetResolveDirectiveDetails(directive string, hasItems, isImplicit bool) (*R
 	strLen := len(directive)
 	hasNamedValue := true
 
+	//isImplicit will try to support both ithem or without item
 	if isImplicit || hasItems {
 		//uses the "item format" (ex. foo[bar].valueName; where 'bar' is the item)
 		if directive[0] != '[' {

--- a/data/resolve/resolve.go
+++ b/data/resolve/resolve.go
@@ -62,6 +62,7 @@ func (i *ResolverInfo) UsesItemFormat() bool {
 	return i.usesItemFormat
 }
 
+// IsImplicit determines if the resolver try to uses the item format and no item format then
 func (i *ResolverInfo) IsImplicit() bool {
 	return i.isImplicit
 }

--- a/data/resolve/resolve_test.go
+++ b/data/resolve/resolve_test.go
@@ -9,70 +9,70 @@ import (
 func TestGetResolveDirectiveDetails(t *testing.T) {
 
 	a := "prop"
-	details, err := GetResolveDirectiveDetails(a, false)
+	details, err := GetResolveDirectiveDetails(a, false, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "prop", details.ValueName)
 	assert.Equal(t, "", details.ItemName)
 	assert.Equal(t, "", details.Path)
 
 	a = "[item]"
-	details, err = GetResolveDirectiveDetails(a, true)
+	details, err = GetResolveDirectiveDetails(a, true, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "item", details.ItemName)
 	assert.Equal(t, "", details.ValueName)
 	assert.Equal(t, "", details.Path)
 
 	a = "[foo.bar.item]"
-	details, err = GetResolveDirectiveDetails(a, true)
+	details, err = GetResolveDirectiveDetails(a, true, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "foo.bar.item", details.ItemName)
 	assert.Equal(t, "", details.ValueName)
 	assert.Equal(t, "", details.Path)
 
 	a = "[item].prop"
-	details, err = GetResolveDirectiveDetails(a, true)
+	details, err = GetResolveDirectiveDetails(a, true, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "prop", details.ValueName)
 	assert.Equal(t, "item", details.ItemName)
 	assert.Equal(t, "", details.Path)
 
 	a = "[mapitem]['foo']"
-	details, err = GetResolveDirectiveDetails(a, true)
+	details, err = GetResolveDirectiveDetails(a, true, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "", details.ValueName)
 	assert.Equal(t, "mapitem", details.ItemName)
 	assert.Equal(t, "['foo']", details.Path)
 
 	a = "[arritem][1]"
-	details, err = GetResolveDirectiveDetails(a, true)
+	details, err = GetResolveDirectiveDetails(a, true, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "", details.ValueName)
 	assert.Equal(t, "arritem", details.ItemName)
 	assert.Equal(t, "[1]", details.Path)
 
 	a = "[item].prop.path"
-	details, err = GetResolveDirectiveDetails(a, true)
+	details, err = GetResolveDirectiveDetails(a, true, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "prop", details.ValueName)
 	assert.Equal(t, "item", details.ItemName)
 	assert.Equal(t, ".path", details.Path)
 
 	a = "[item].prop['map']"
-	details, err = GetResolveDirectiveDetails(a, true)
+	details, err = GetResolveDirectiveDetails(a, true, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "prop", details.ValueName)
 	assert.Equal(t, "item", details.ItemName)
 	assert.Equal(t, "['map']", details.Path)
 
 	a = "[item].prop[0]"
-	details, err = GetResolveDirectiveDetails(a, true)
+	details, err = GetResolveDirectiveDetails(a, true, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "prop", details.ValueName)
 	assert.Equal(t, "item", details.ItemName)
 	assert.Equal(t, "[0]", details.Path)
 
 	a = ".value"
-	details, err = GetResolveDirectiveDetails(a, false)
+	details, err = GetResolveDirectiveDetails(a, false, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "value", details.ValueName)
 	assert.Equal(t, "", details.ItemName)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[*] Other... Please describe: Change the way of access current loop element
```

**Fixes**: #79 

**What is the current behavior?**
Please have a look #79.  Today we are using `$.` to access current scope data which also use to access array mapping current loop.
**What is the new behavior?**
With this PR, we changed to `$loop.xxx` to access the current loop.

@fm-tibco I added one more field call IsImplicit in ResoverInfo which indicate the resolver intent to support both(has item or no item).

As the loop to be supported.
`$loop.xxx`  to access the current loop element
`$loop[name].xxx` to access out loop or parent loop elements.
Please let me know you thoughts