### PR TITLE
return original array if no child mapping for array mapping

### DIFF
--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -224,6 +224,12 @@ func (f *foreach) handle(arrayMappingFields map[string]interface{}, inputScope d
 		objectMapperLog.Errorf("foreach source [%+v] not an array, cast to array error %s", fromValue, err.Error())
 		return nil, fmt.Errorf("foreach source [%+v] not an array", fromValue)
 	}
+
+	if arrayMappingFields == nil || len(arrayMappingFields) <= 0 {
+		//No child mapping, return original
+		return newSourceArray, nil
+	}
+
 	targetValues := make([]interface{}, len(newSourceArray))
 	for i, sourceValue := range newSourceArray {
 		inputScope = newLoopScope(sourceValue, f.index, inputScope)

--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -233,6 +233,8 @@ func (f *foreach) handle(arrayMappingFields map[string]interface{}, inputScope d
 		}
 	}
 
+	arrayMappingFields = removeAssignFromArrayMappingFeild(arrayMappingFields)
+
 	if len(arrayMappingFields) > 0 {
 		for i, sourceValue := range newSourceArray {
 			inputScope = newLoopScope(sourceValue, f.index, inputScope)
@@ -272,6 +274,17 @@ func (f *foreach) handle(arrayMappingFields map[string]interface{}, inputScope d
 	return targetValues, nil
 }
 
+func removeAssignFromArrayMappingFeild(arrayMappingFields map[string]interface{}) map[string]interface{} {
+	tmpArrayField := make(map[string]interface{})
+	for k, v := range arrayMappingFields {
+		if k != "=" {
+			tmpArrayField[k] = v
+		}
+	}
+
+	return tmpArrayField
+}
+
 func hasArrayAssign(arrayMappingFields map[string]interface{}) bool {
 	field, ok := arrayMappingFields["="]
 	if ok && field != nil {
@@ -296,8 +309,6 @@ func (f *foreach) handleArrayAssign(sourceArray []interface{}, arrayMappingField
 				targetValues[i] = fromValue
 			}
 		}
-		//delete = element from array to make it continue on all possible child field which for updating
-		delete(arrayMappingFields, "=")
 	}
 	return targetValues, nil
 }

--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -225,22 +225,81 @@ func (f *foreach) handle(arrayMappingFields map[string]interface{}, inputScope d
 		return nil, fmt.Errorf("foreach source [%+v] not an array", fromValue)
 	}
 
-	if arrayMappingFields == nil || len(arrayMappingFields) <= 0 {
-		//No child mapping, return original
-		return newSourceArray, nil
+	targetValues := make([]interface{}, len(newSourceArray))
+	if hasArrayAssign(arrayMappingFields) {
+		targetValues, err = f.handleArrayAssign(newSourceArray, arrayMappingFields, inputScope)
+		if err != nil {
+			return nil, fmt.Errorf("array assign error, %s", err.Error())
+		}
 	}
 
-	targetValues := make([]interface{}, len(newSourceArray))
-	for i, sourceValue := range newSourceArray {
-		inputScope = newLoopScope(sourceValue, f.index, inputScope)
-		item, err := handleObjectMapping(arrayMappingFields, f.exprFactory, inputScope)
-		if err != nil {
-			return nil, err
+	if len(arrayMappingFields) > 0 {
+		for i, sourceValue := range newSourceArray {
+			inputScope = newLoopScope(sourceValue, f.index, inputScope)
+			item, err := handleObjectMapping(arrayMappingFields, f.exprFactory, inputScope)
+			if err != nil {
+				return nil, err
+			}
+			if targetValues[i] == nil {
+				targetValues[i] = item
+			} else {
+				//update value
+				switch t := item.(type) {
+				case map[string]interface{}:
+					targetValue, ok := targetValues[i].(map[string]interface{})
+					if ok {
+						for k, v := range t {
+							targetValue[k] = v
+						}
+					} else {
+						return nil, fmt.Errorf("cannot assign map[string]interface to [%s]", reflect.TypeOf(targetValues[i]))
+					}
+				case []interface{}:
+					targetValue, ok := targetValues[i].([]interface{})
+					if ok {
+						for k, v := range t {
+							targetValue[k] = v
+						}
+					} else {
+						return nil, fmt.Errorf("cannot assign []interface to [%s]", reflect.TypeOf(targetValues[i]))
+					}
+				}
+			}
 		}
-		targetValues[i] = item
+		return targetValues, nil
+	}
+
+	return targetValues, nil
+}
+
+func hasArrayAssign(arrayMappingFields map[string]interface{}) bool {
+	field, ok := arrayMappingFields["="]
+	if ok && field != nil {
+		return true
+	}
+	return false
+}
+
+func (f *foreach) handleArrayAssign(sourceArray []interface{}, arrayMappingFields map[string]interface{}, inputScope data.Scope) ([]interface{}, error) {
+	targetValues := make([]interface{}, len(sourceArray))
+	field, ok := arrayMappingFields["="]
+	if ok && field != nil {
+		if v, ok := field.(string); ok && v == "$loop" {
+			targetValues = sourceArray
+		} else {
+			for i, sourceValue := range sourceArray {
+				inputScope = newLoopScope(sourceValue, f.index, inputScope)
+				fromValue, err := getExpressionValue(field, f.exprFactory, inputScope)
+				if err != nil {
+					return nil, fmt.Errorf("eval expression failed %s", err.Error())
+				}
+				targetValues[i] = fromValue
+			}
+		}
+		//delete = element from array to make it continue on all possible child field which for updating
+		delete(arrayMappingFields, "=")
 	}
 	return targetValues, nil
-
 }
 
 func handleObject(targetValue map[string]interface{}, targetName string, source interface{}, exprF expression.Factory, scope data.Scope) error {

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -2,7 +2,6 @@ package mapper
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/project-flogo/core/data"
 	"github.com/project-flogo/core/data/resolve"
 	"testing"
@@ -640,8 +639,6 @@ func TestArrayMappingNoChildMapping(t *testing.T) {
 	scope := data.NewSimpleScope(attrs, nil)
 	results, err := mapper.Apply(scope)
 	assert.Nil(t, err)
-	v, _ := json.Marshal(results)
-	fmt.Println(string(v))
 	arr := results["addresses"]
 	assert.Equal(t, "person", arr.(map[string]interface{})["person2"])
 	assert.Equal(t, float64(77479), arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tozipcode"])
@@ -650,6 +647,10 @@ func TestArrayMappingNoChildMapping(t *testing.T) {
 	assert.Equal(t, "hello", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["addresses2"].([]interface{})[0].(map[string]interface{})["field1"])
 	assert.Equal(t, "field2value", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["addresses2"].([]interface{})[0].(map[string]interface{})["field2"])
 	assert.Equal(t, "field3value", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["addresses2"].([]interface{})[0].(map[string]interface{})["field3"])
+
+	assert.Equal(t, "hello", arr.(map[string]interface{})["addresses"].([]interface{})[1].(map[string]interface{})["addresses2"].([]interface{})[1].(map[string]interface{})["field1"])
+	assert.Equal(t, "field2value22", arr.(map[string]interface{})["addresses"].([]interface{})[1].(map[string]interface{})["addresses2"].([]interface{})[1].(map[string]interface{})["field2"])
+	assert.Equal(t, "field3value22", arr.(map[string]interface{})["addresses"].([]interface{})[1].(map[string]interface{})["addresses2"].([]interface{})[1].(map[string]interface{})["field3"])
 
 }
 

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -563,6 +563,88 @@ func TestArrayMappingWithNestComplexObject(t *testing.T) {
 
 }
 
+func TestArrayMappingNoChildMapping(t *testing.T) {
+	mappingValue := `{"mapping": {
+        "person2" : "person",
+        "addresses": {
+            "@foreach($.field.addresses, index)":
+            {
+              "tostate"   : "=$loop[index].state",
+               "tostreet": "=$loop.street.number",
+               "tozipcode":"=$loop.zipcode",
+              "addresses2": {
+                  "@foreach($loop.array)":{}
+              }
+            }
+        }
+    }}`
+
+	arrayData := `{
+   "person": "name",
+   "addresses": [
+       {
+           "street": {
+				"number":"1234"
+           },
+           "zipcode": 77479,
+           "state": "tx",
+			"array":[
+				{
+					"field1":"field1value",
+					"field2":"field2value",
+					"field3":"field3value"
+				},
+				{
+					"field1":"field1value2",
+					"field2":"field2value2",
+					"field3":"field3value2"
+				}
+			]
+       },
+ {
+          "street": {
+				"number":"3333"
+           },
+           "zipcode": 774792,
+           "state": "tx2",
+			"array":[
+				{
+					"field1":"field1value2",
+					"field2":"field2value2",
+					"field3":"field3value2"
+				},
+				{
+					"field1":"field1value22",
+					"field2":"field2value22",
+					"field3":"field3value22"
+				}
+			]
+       }
+   ]
+}`
+
+	arrayMapping := make(map[string]interface{})
+	err := json.Unmarshal([]byte(mappingValue), &arrayMapping)
+	assert.Nil(t, err)
+	assert.False(t, IsLiteral(arrayMapping))
+	mappings := map[string]interface{}{"addresses": arrayMapping}
+	factory := NewFactory(resolve.GetBasicResolver())
+	mapper, err := factory.NewMapper(mappings)
+	assert.Nil(t, err)
+
+	attrs := map[string]interface{}{"field": arrayData}
+	scope := data.NewSimpleScope(attrs, nil)
+	results, err := mapper.Apply(scope)
+	assert.Nil(t, err)
+	arr := results["addresses"]
+	assert.Equal(t, "person", arr.(map[string]interface{})["person2"])
+	assert.Equal(t, float64(77479), arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tozipcode"])
+	assert.Equal(t, "1234", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tostreet"])
+	assert.Equal(t, "tx", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["tostate"])
+	assert.Equal(t, "field1value", arr.(map[string]interface{})["addresses"].([]interface{})[0].(map[string]interface{})["addresses2"].([]interface{})[0].(map[string]interface{})["field1"])
+
+}
+
 func TestArrayMappingWithFunction3Level(t *testing.T) {
 	mappingValue := `{"mapping": {
    "person2":"person",


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**

**What is the new behavior?**
If there is no child mapping for array mapping then we return original data. such as:
```
     "array": {
                  "@foreach($activity[rest].data.array)":{}
         }
```

We will copy `$activity[rest].data.array` to `array`.  This is the behavior we did in flogo-lib,  so make these changes to keep consistency with previous.