### PR TITLE
Get object value base on field name and json tag name

### DIFF
--- a/data/path/path.go
+++ b/data/path/path.go
@@ -91,7 +91,7 @@ func getFieldValueByName(object interface{}, name string) (interface{}, error) {
 		}
 	}
 
-	return reflect.Value{}, nil
+	return nil, nil
 }
 
 func SetValue(attrValue interface{}, path string, value interface{}) error {

--- a/data/path/path.go
+++ b/data/path/path.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/project-flogo/core/data/coerce"
 	"reflect"
 	"strconv"
 	"strings"
-	"unicode"
-
-	"github.com/project-flogo/core/data/coerce"
 )
 
 //todo consolidate and optimize code
@@ -40,28 +38,12 @@ func GetValue(value interface{}, path string) (interface{}, error) {
 		} else if paramsVal, ok := value.(map[string]string); ok {
 			newVal, newPath, err = getSetParamsValue(paramsVal, path, nil, false)
 		} else {
-
-			val := reflect.ValueOf(value)
-			if val.Kind() == reflect.Ptr {
-				val = val.Elem()
+			fieldName, npIdx := getObjectKey(path[1:])
+			newVal, err = getFieldValueByName(value, fieldName)
+			if err != nil {
+				return nil, err
 			}
-
-			if val.Kind() == reflect.Struct {
-				fieldName, npIdx := getObjectKey(path[1:])
-				fieldName = NormalizeFieldName(fieldName)
-				newPath = path[npIdx:]
-				f := val.FieldByName(fieldName)
-				if !f.IsValid() {
-					if newPath == "" {
-						return nil, nil
-					}
-					return nil, errors.New("Invalid path '" + path + "'. path not found.")
-				}
-
-				newVal = f.Interface()
-			} else {
-				return nil, fmt.Errorf("unable to evaluate path: %s", path)
-			}
+			newPath = path[npIdx:]
 		}
 	} else if strings.HasPrefix(path, `["`) {
 		if objVal, ok := value.(map[string]interface{}); ok {
@@ -83,10 +65,33 @@ func GetValue(value interface{}, path string) (interface{}, error) {
 	return GetValue(newVal, newPath)
 }
 
-func NormalizeFieldName(name string) string {
-	symbols := []rune(name)
-	symbols[0] = unicode.ToUpper(symbols[0])
-	return string(symbols)
+func getFieldValueByName(object interface{}, name string) (interface{}, error) {
+	val := reflect.ValueOf(object)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	field := val.FieldByName(name)
+	if field.IsValid() {
+		return field.Interface(), nil
+	}
+
+	typ := reflect.TypeOf(object)
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		p := typ.Field(i)
+		if !p.Anonymous {
+			if p.Tag != "" && len(p.Tag) > 0 {
+				if name == p.Tag.Get("json") {
+					return val.FieldByName(typ.Field(i).Name).Interface(), nil
+				}
+			}
+		}
+	}
+
+	return reflect.Value{}, nil
 }
 
 func SetValue(attrValue interface{}, path string, value interface{}) error {

--- a/data/path/path.go
+++ b/data/path/path.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 //todo consolidate and optimize code
@@ -71,7 +72,7 @@ func getFieldValueByName(object interface{}, name string) (interface{}, error) {
 		val = val.Elem()
 	}
 
-	field := val.FieldByName(name)
+	field := val.FieldByName(NormalizeFieldName(name))
 	if field.IsValid() {
 		return field.Interface(), nil
 	}
@@ -91,7 +92,13 @@ func getFieldValueByName(object interface{}, name string) (interface{}, error) {
 		}
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf("unable to evaluate path: %s", name)
+}
+
+func NormalizeFieldName(name string) string {
+	symbols := []rune(name)
+	symbols[0] = unicode.ToUpper(symbols[0])
+	return string(symbols)
 }
 
 func SetValue(attrValue interface{}, path string, value interface{}) error {

--- a/data/path/path.go
+++ b/data/path/path.go
@@ -72,26 +72,29 @@ func getFieldValueByName(object interface{}, name string) (interface{}, error) {
 		val = val.Elem()
 	}
 
-	field := val.FieldByName(NormalizeFieldName(name))
-	if field.IsValid() {
-		return field.Interface(), nil
-	}
+	if val.Kind() == reflect.Struct {
 
-	typ := reflect.TypeOf(object)
-	if typ.Kind() == reflect.Ptr {
-		typ = typ.Elem()
-	}
-	for i := 0; i < typ.NumField(); i++ {
-		p := typ.Field(i)
-		if !p.Anonymous {
-			if p.Tag != "" && len(p.Tag) > 0 {
-				if name == p.Tag.Get("json") {
-					return val.FieldByName(typ.Field(i).Name).Interface(), nil
+		field := val.FieldByName(NormalizeFieldName(name))
+		if field.IsValid() {
+			return field.Interface(), nil
+		}
+
+		typ := reflect.TypeOf(object)
+		if typ.Kind() == reflect.Ptr {
+			typ = typ.Elem()
+		}
+		for i := 0; i < typ.NumField(); i++ {
+			p := typ.Field(i)
+			if !p.Anonymous {
+				if p.Tag != "" && len(p.Tag) > 0 {
+					if name == p.Tag.Get("json") {
+						return val.FieldByName(typ.Field(i).Name).Interface(), nil
+					}
 				}
 			}
 		}
-	}
 
+	}
 	return nil, fmt.Errorf("unable to evaluate path: %s", name)
 }
 

--- a/data/path/path_test.go
+++ b/data/path/path_test.go
@@ -99,7 +99,7 @@ func TestGetValue(t *testing.T) {
 
 	path = ".test.gah"
 	newVal, err = GetValue(multiLevel, path)
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 	assert.Nil(t, newVal)
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
The connector defined a struct with json tag.  they use json tag name as mapping ref to access the value but it cannot today
**What is the new behavior?**
Fix it by getting value from object field name or json tag name.
1. Try to get value from the field name.
2.  Try to json tag if first 1 invalid.
