### PR TITLE
Fixing check literal 

### DIFF
--- a/data/expression/util.go
+++ b/data/expression/util.go
@@ -27,7 +27,7 @@ func GetLiteral(strVal string) (interface{}, bool) {
 	}
 
 	//check if is string
-	s, isStr := isQuotesString(newStrVal)
+	s, isStr := isQuotedString(newStrVal)
 	if isStr {
 		return s, true
 	}
@@ -51,7 +51,7 @@ func GetLiteral(strVal string) (interface{}, bool) {
 	return nil, false
 }
 
-func isQuotesString(newStrVal string) (string, bool) {
+func isQuotedString(newStrVal string) (string, bool) {
 	//String must surround with quotes and only one pair
 	if newStrVal[0] == '"' {
 		newStrVal = newStrVal[1:]

--- a/data/expression/util.go
+++ b/data/expression/util.go
@@ -27,14 +27,9 @@ func GetLiteral(strVal string) (interface{}, bool) {
 	}
 
 	//check if is string
-	if newStrVal[0] == '`' && newStrVal[len(newStrVal)-1] == '`' {
-		return newStrVal[1 : len(newStrVal)-1], true
-	}
-	if newStrVal[0] == '\'' && newStrVal[len(newStrVal)-1] == '\'' {
-		return newStrVal[1 : len(newStrVal)-1], true
-	}
-	if newStrVal[0] == '"' && newStrVal[len(newStrVal)-1] == '"' {
-		return newStrVal[1 : len(newStrVal)-1], true
+	s, isStr := isQuotesString(newStrVal)
+	if isStr {
+		return s, true
 	}
 
 	//check for booleans
@@ -54,4 +49,29 @@ func GetLiteral(strVal string) (interface{}, bool) {
 	}
 
 	return nil, false
+}
+
+func isQuotesString(newStrVal string) (string, bool) {
+	//String must surround with quotes and only one pair
+	if newStrVal[0] == '"' {
+		newStrVal = newStrVal[1:]
+		if len(newStrVal) == strings.Index(newStrVal, `"`)+1 {
+			return newStrVal[:len(newStrVal)-1], true
+		}
+		return "", false
+	} else if newStrVal[0] == '\'' {
+		newStrVal = newStrVal[1:]
+		if len(newStrVal) == strings.Index(newStrVal, `'`)+1 {
+			return newStrVal[:len(newStrVal)-1], true
+		}
+		return "", false
+
+	} else if newStrVal[0] == '`' {
+		newStrVal = newStrVal[1:]
+		if len(newStrVal) == strings.Index(newStrVal, "`")+1 {
+			return newStrVal[:len(newStrVal)-1], true
+		}
+		return "", false
+	}
+	return "", false
 }

--- a/data/expression/util_test.go
+++ b/data/expression/util_test.go
@@ -61,3 +61,28 @@ func TestGetLiteral(t *testing.T) {
 	assert.True(t, ok2)
 	assert.False(t, b)
 }
+
+func TestIsString(t *testing.T) {
+	_, b := isQuotesString("lixingwang")
+	assert.False(t, b)
+
+	v, b := isQuotesString(`"ddddd"`)
+	assert.True(t, b)
+	assert.Equal(t, "ddddd", v)
+	_, b = isQuotesString(`"ddddd" ==  "dddddd"`)
+	assert.False(t, b)
+
+	_, b = isQuotesString(`"ddddd" ==  'ddddd'`)
+	assert.False(t, b)
+
+	//Single
+
+	v, b = isQuotesString(`'ddddd'`)
+	assert.True(t, b)
+	assert.Equal(t, "ddddd", v)
+	_, b = isQuotesString(`'ddddd' ==  'dddd'`)
+	assert.False(t, b)
+
+	_, b = isQuotesString("`ddddd` ==  `ddddd`")
+	assert.False(t, b)
+}

--- a/data/expression/util_test.go
+++ b/data/expression/util_test.go
@@ -63,26 +63,26 @@ func TestGetLiteral(t *testing.T) {
 }
 
 func TestIsString(t *testing.T) {
-	_, b := isQuotesString("lixingwang")
+	_, b := isQuotedString("lixingwang")
 	assert.False(t, b)
 
-	v, b := isQuotesString(`"ddddd"`)
+	v, b := isQuotedString(`"ddddd"`)
 	assert.True(t, b)
 	assert.Equal(t, "ddddd", v)
-	_, b = isQuotesString(`"ddddd" ==  "dddddd"`)
+	_, b = isQuotedString(`"ddddd" ==  "dddddd"`)
 	assert.False(t, b)
 
-	_, b = isQuotesString(`"ddddd" ==  'ddddd'`)
+	_, b = isQuotedString(`"ddddd" ==  'ddddd'`)
 	assert.False(t, b)
 
 	//Single
 
-	v, b = isQuotesString(`'ddddd'`)
+	v, b = isQuotedString(`'ddddd'`)
 	assert.True(t, b)
 	assert.Equal(t, "ddddd", v)
-	_, b = isQuotesString(`'ddddd' ==  'dddd'`)
+	_, b = isQuotedString(`'ddddd' ==  'dddd'`)
 	assert.False(t, b)
 
-	_, b = isQuotesString("`ddddd` ==  `ddddd`")
+	_, b = isQuotedString("`ddddd` ==  `ddddd`")
 	assert.False(t, b)
 }


### PR DESCRIPTION
… quotes

**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Expression `"flogo" == "flogo"` be treated at literal rather than expression.
**What is the new behavior?**
The quotes string must be surrounded with quotes and only have one pair of quotes
