### PR TITLE
Handle escaped double quotes and single quotes

### DIFF
--- a/data/expression/script/expr_test.go
+++ b/data/expression/script/expr_test.go
@@ -851,6 +851,20 @@ func TestExpression(t *testing.T) {
 	}
 }
 
+func TestEscapedExpr(t *testing.T) {
+	expr, err := factory.NewExpr(`script.concat("\"Hello\" ", '\'FLOGO\'')`)
+	assert.Nil(t, err)
+	v, err := expr.Eval(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, `"Hello" 'FLOGO'`, v)
+
+	expr, err = factory.NewExpr("script.concat(`Hello `, `'FLOGO'`)")
+	assert.Nil(t, err)
+	v, err = expr.Eval(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, `Hello 'FLOGO'`, v)
+}
+
 var result interface{}
 
 func BenchmarkLit(b *testing.B) {

--- a/data/expression/script/gocc/ast/literal.go
+++ b/data/expression/script/gocc/ast/literal.go
@@ -38,11 +38,32 @@ func NewLiteral(litType string, lit interface{}) (Expr, error) {
 		b, err := coerce.ToBool(litAsStr)
 		return &literalExpr{val: b, typ: "bool"}, err
 	case "string":
-		s := litAsStr[1 : len(litAsStr)-1] //remove quotes
-		return &literalExpr{val: s, typ: "string"}, nil
+		return &literalExpr{val: removeQuotedAndEscaped(litAsStr), typ: "string"}, nil
 	case "nil":
 		return &literalExpr{val: nil, typ: "nil"}, nil
 	}
 
 	return nil, fmt.Errorf("unsupported literal type '%s'", litType)
+}
+
+func removeQuotedAndEscaped(str string) string {
+	//Eascap string
+	firstChar := str[0]
+	switch firstChar {
+	case '"':
+		str = str[1 : len(str)-1]
+		if strings.Contains(str, "\\\"") {
+			str = strings.Replace(str, `\"`, `"`, -1)
+		}
+	case '\'':
+		str = str[1 : len(str)-1]
+		//Eascap string
+		if strings.Contains(str, "\\'") {
+			str = strings.Replace(str, "\\'", "'", -1)
+		}
+	default:
+		str = str[1 : len(str)-1]
+	}
+	return str
+
 }

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -700,7 +700,7 @@ func TestArrayMappingPrimitiveArray(t *testing.T) {
 	assert.Nil(t, err)
 	arr := results["addresses"]
 	assert.Equal(t, "person", arr.(map[string]interface{})["person2"])
-	assert.Equal(t, []string{"tx", "tx2"}, arr.(map[string]interface{})["states"])
+	assert.Equal(t, []interface{}{"tx", "tx2"}, arr.(map[string]interface{})["states"])
 
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today we have issue handle escaped quotes in expr.  such as `string.concat("\"Hello\" ", '\'FLOGO\'')`

Expected result: `"Hello" 'FLOGO'`
**What is the new behavior?**
Handle in expression to get correct escaped value