### PR TITLE
Add builtin function isDefined and getValue

### DIFF
--- a/data/expression/script/expr_test.go
+++ b/data/expression/script/expr_test.go
@@ -914,11 +914,11 @@ func TestBuiltInFunction(t *testing.T) {
 			ExpectResult: false,
 		},
 		{
-			Expr:         "DefaultTo($.foo.store.exit, \"flogo\")",
+			Expr:         "getValue($.foo.store.exit, \"flogo\")",
 			ExpectResult: "flogo",
 		},
 		{
-			Expr:         "DefaultTo($.foo['store'].book[2].price, \"flogo\")",
+			Expr:         "getValue($.foo['store'].book[2].price, \"flogo\")",
 			ExpectResult: 8.99,
 		},
 	}

--- a/data/expression/script/expr_test.go
+++ b/data/expression/script/expr_test.go
@@ -893,6 +893,53 @@ rld`, v)
 FLOGO`, v)
 }
 
+func TestBuiltInFunction(t *testing.T) {
+
+	var testData interface{}
+	err := json.Unmarshal([]byte(testJsonData), &testData)
+	assert.Nil(t, err)
+
+	scope := newScope(map[string]interface{}{"foo": testData, "key": 2})
+
+	tests := []struct {
+		Expr         string
+		ExpectResult interface{}
+	}{
+		{
+			Expr:         "isDefined($.foo['store'].book[2].price)",
+			ExpectResult: true,
+		},
+		{
+			Expr:         "isDefined($.foo.store.exit)",
+			ExpectResult: false,
+		},
+		{
+			Expr:         "DefaultTo($.foo.store.exit, \"flogo\")",
+			ExpectResult: "flogo",
+		},
+		{
+			Expr:         "DefaultTo($.foo['store'].book[2].price, \"flogo\")",
+			ExpectResult: 8.99,
+		},
+	}
+
+	for i, tt := range tests {
+
+		expr, err := factory.NewExpr(tt.Expr)
+		assert.Nil(t, err)
+		v, err := expr.Eval(scope)
+		assert.Nil(t, err)
+		if assert.NoError(t, err, "Unexpected error in case #%d.", i) {
+			assert.Equal(
+				t,
+				tt.ExpectResult,
+				v,
+				"Unexpected expression output: expected to %v.", tt.ExpectResult,
+			)
+		}
+	}
+}
+
 var result interface{}
 
 func BenchmarkLit(b *testing.B) {

--- a/data/expression/script/gocc/ast/builtin.go
+++ b/data/expression/script/gocc/ast/builtin.go
@@ -19,12 +19,12 @@ func (d *IsDefinedExpr) Eval(scope data.Scope) (interface{}, error) {
 	return isDefine, err
 }
 
-type DefaultToExpr struct {
+type GetValueExpr struct {
 	refExpr   Expr
 	valueExpr Expr
 }
 
-func (d *DefaultToExpr) Init(resolver resolve.CompositeResolver, root bool) error {
+func (d *GetValueExpr) Init(resolver resolve.CompositeResolver, root bool) error {
 	err := d.refExpr.Init(resolver, root)
 	if err != nil {
 		return err
@@ -33,7 +33,7 @@ func (d *DefaultToExpr) Init(resolver resolve.CompositeResolver, root bool) erro
 
 }
 
-func (d *DefaultToExpr) Eval(scope data.Scope) (interface{}, error) {
+func (d *GetValueExpr) Eval(scope data.Scope) (interface{}, error) {
 	v, isDefine, err := isDefined(d.refExpr, scope)
 	if err != nil {
 		return nil, err

--- a/data/expression/script/gocc/ast/builtin.go
+++ b/data/expression/script/gocc/ast/builtin.go
@@ -1,0 +1,57 @@
+package ast
+
+import (
+	"github.com/project-flogo/core/data"
+	"github.com/project-flogo/core/data/resolve"
+	"strings"
+)
+
+type IsDefinedExpr struct {
+	refExpr Expr
+}
+
+func (d *IsDefinedExpr) Init(resolver resolve.CompositeResolver, root bool) error {
+	return d.refExpr.Init(resolver, root)
+}
+
+func (d *IsDefinedExpr) Eval(scope data.Scope) (interface{}, error) {
+	_, isDefine, err := isDefined(d.refExpr, scope)
+	return isDefine, err
+}
+
+type DefaultToExpr struct {
+	refExpr   Expr
+	valueExpr Expr
+}
+
+func (d *DefaultToExpr) Init(resolver resolve.CompositeResolver, root bool) error {
+	err := d.refExpr.Init(resolver, root)
+	if err != nil {
+		return err
+	}
+	return d.valueExpr.Init(resolver, root)
+
+}
+
+func (d *DefaultToExpr) Eval(scope data.Scope) (interface{}, error) {
+	v, isDefine, err := isDefined(d.refExpr, scope)
+	if err != nil {
+		return nil, err
+	}
+	if !isDefine {
+		return d.valueExpr.Eval(scope)
+	}
+	return v, nil
+}
+
+func isDefined(expr Expr, scope data.Scope) (interface{}, bool, error) {
+	v, err := expr.Eval(scope)
+	if err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "path not found") || strings.Contains(msg, "unable to evaluate path") {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return v, v != nil, nil
+}

--- a/data/expression/script/gocc/ast/function.go
+++ b/data/expression/script/gocc/ast/function.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/project-flogo/core/data"
 	"github.com/project-flogo/core/data/expression/function"
@@ -11,6 +12,11 @@ import (
 
 func NewFuncExpr(name interface{}, args interface{}) (Expr, error) {
 	funcName := string(name.(*token.Token).Lit)
+	if strings.EqualFold(funcName, "isdefined") {
+		return &IsDefinedExpr{refExpr: args.([]Expr)[0]}, nil
+	} else if strings.EqualFold(funcName, "defaultto") {
+		return &DefaultToExpr{refExpr: args.([]Expr)[0], valueExpr: args.([]Expr)[1]}, nil
+	}
 
 	f := function.Get(funcName)
 	if f == nil {

--- a/data/expression/script/gocc/ast/function.go
+++ b/data/expression/script/gocc/ast/function.go
@@ -14,8 +14,8 @@ func NewFuncExpr(name interface{}, args interface{}) (Expr, error) {
 	funcName := string(name.(*token.Token).Lit)
 	if strings.EqualFold(funcName, "isdefined") {
 		return &IsDefinedExpr{refExpr: args.([]Expr)[0]}, nil
-	} else if strings.EqualFold(funcName, "defaultto") {
-		return &DefaultToExpr{refExpr: args.([]Expr)[0], valueExpr: args.([]Expr)[1]}, nil
+	} else if strings.EqualFold(funcName, "getValue") {
+		return &GetValueExpr{refExpr: args.([]Expr)[0], valueExpr: args.([]Expr)[1]}, nil
 	}
 
 	f := function.Get(funcName)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[*] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
1. There is no function to check the mapping node exist or not
2. No function to set a default value while mapping node doesn't exist
**What is the new behavior?**
1. Added builtin function `isDefined($.xxxxx)`
2. Added builtin function `getValue($.xxxxx, "defaultValue")`
