### PR TITLE
Shared SSL Config

### DIFF
--- a/support/ssl/client.go
+++ b/support/ssl/client.go
@@ -3,9 +3,9 @@ package ssl
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/project-flogo/core/data/coerce"
 	"io/ioutil"
 
+	"github.com/project-flogo/core/data/coerce"
 	"github.com/project-flogo/core/support/log"
 )
 

--- a/support/ssl/client.go
+++ b/support/ssl/client.go
@@ -3,6 +3,7 @@ package ssl
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"github.com/project-flogo/core/data/coerce"
 	"io/ioutil"
 
 	"github.com/project-flogo/core/support/log"
@@ -37,6 +38,43 @@ type Config struct {
 	KeyFile       string `json:"keyFile"`
 	SkipVerify    bool   `json:"skipVerify"`
 	UseSystemCert bool   `json:"useSystemCert"`
+}
+
+func (i *Config) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"caFile":        i.CAFile,
+		"certFile":      i.CertFile,
+		"keyFile":       i.KeyFile,
+		"skipVerify":    i.SkipVerify,
+		"useSystemCert": i.UseSystemCert,
+	}
+}
+
+func (i *Config) FromMap(values map[string]interface{}) error {
+
+	var err error
+	i.CAFile, err = coerce.ToString(values["caFile"])
+	if err != nil {
+		return err
+	}
+	i.CertFile, err = coerce.ToString(values["certFile"])
+	if err != nil {
+		return err
+	}
+	i.KeyFile, err = coerce.ToString(values["keyFile"])
+	if err != nil {
+		return err
+	}
+	i.SkipVerify, err = coerce.ToBool(values["skipVerify"])
+	if err != nil {
+		return err
+	}
+	i.UseSystemCert, err = coerce.ToBool(values["useSystemCert"])
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func NewClientTLSConfig(config *Config) (*tls.Config, error) {

--- a/support/ssl/client.go
+++ b/support/ssl/client.go
@@ -1,0 +1,81 @@
+package ssl
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+
+	"github.com/project-flogo/core/support/log"
+)
+
+const ConfigSchema = `
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "caFile": {
+      "type": "string"
+    },
+    "certFile": {
+      "type": "string"
+    },
+    "keyFile": {
+      "type": "string"
+    },
+    "skipVerify": {
+      "type": "boolean"
+    },
+    "useSystemCert": {
+      "type": "boolean"
+    }
+  }
+}`
+
+type Config struct {
+	CAFile        string `json:"caFile"`
+	CertFile      string `json:"certFile"`
+	KeyFile       string `json:"keyFile"`
+	SkipVerify    bool   `json:"skipVerify"`
+	UseSystemCert bool   `json:"useSystemCert"`
+}
+
+func NewClientTLSConfig(config *Config) (*tls.Config, error) {
+	tlsConfig := &tls.Config{
+		//MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: config.SkipVerify,
+	}
+
+	var caCertPool *x509.CertPool
+
+	if config.UseSystemCert {
+		caCertPool, _ = x509.SystemCertPool()
+		if caCertPool == nil {
+			log.RootLogger().Warnf("unable to get system cert pool, using empty pool")
+		}
+	}
+
+	if caCertPool == nil {
+		caCertPool = x509.NewCertPool()
+	}
+
+	if config.CAFile != "" {
+		caCert, err := ioutil.ReadFile(config.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool.AppendCertsFromPEM(caCert)
+	}
+
+	tlsConfig.RootCAs = caCertPool
+
+	if config.CertFile != "" && config.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(config.CertFile, config.CertFile)
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsConfig, nil
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**

**What is the new behavior?**

Seems like this code is duplicated everywhere and done differently everywhere.  I propose we add this package which people can use in their contribs that use TLS.  In addition to sharing the same code, we can also have contribs just use a single field in their settings for TLS.  Which is really nice for configuration is someone isn't using it.

So instead of: 
```
  "settings": [
    {
      "name": "method",
      "type": "string",
      "required": true,
      "allowed": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
      "description" : "The HTTP method to invoke"
    },
    {
      "name": "uri",
      "type": "string",
      "required": true,
      "description" : "The URI of the service to invoke"
    },
    {
      "name": "skipSSLVerify",
      "type": "boolean",
      "value": "false",
      "description" : "Skip SSL validation"
    },
        {
      "name": "useSystemCert",
      "type": "boolean",
      "value": "false",
      "description" : "Use System Cert"
    },
    {
      "name": "certFile",
      "type":"string",
      "description" : "Path to PEM encoded client certificate"
    },
    {
      "name": "keyFile",
      "type":"string",
      "description" : "Path to PEM encoded client key"
    },
    {
      "name": "caFile",
      "type":"string",
      "description" : "Path to PEM encoded root certificates file"
    }
  ],
```
Use this:
```
    "settings": [
    {
      "name": "method",
      "type": "string",
      "required": true,
      "allowed": [ "GET", "POST", "PUT", "PATCH", "DELETE" ],
      "description" : "The HTTP method to invoke"
    },
    {
      "name": "uri",
      "type": "string",
      "required": true,
      "description" : "The URI of the service to invoke"
    }
    {
      "name": "sslConfig",
      "type": "object",
      "description" : "Optional SSL Settings"
    },
```
where SSLConfig has an associated schema:
```
 {
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "object",
  "properties": {
    "caFile": {
      "type": "string"
    },
    "certFile": {
      "type": "string"
    },
    "keyFile": {
      "type": "string"
    },
    "skipVerify": {
      "type": "boolean"
    },
    "useSystemCert": {
      "type": "boolean"
    }
  }
}```
