### PR TITLE
handle json tag with omitempty

### DIFF
--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -5,6 +5,7 @@ import (
 	"github.com/project-flogo/core/data"
 	"github.com/project-flogo/core/data/coerce"
 	"github.com/project-flogo/core/data/expression"
+	"github.com/project-flogo/core/data/path"
 	"github.com/project-flogo/core/support/log"
 	"reflect"
 	"runtime/debug"
@@ -403,8 +404,9 @@ func ToObjectMap(value interface{}) (map[string]interface{}, error) {
 				// gets us a StructField
 				fi := typ.Field(i)
 				if !fi.Anonymous {
-					if tagv := fi.Tag.Get("json"); tagv != "" {
-						out[tagv] = v.Field(i).Interface()
+					jsonTag := path.GetJsonTag(fi)
+					if len(jsonTag) > 0 {
+						out[jsonTag] = v.Field(i).Interface()
 					} else {
 						out[fi.Name] = v.Field(i).Interface()
 					}

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -499,7 +499,7 @@ func TestArrayMappingWithStruct(t *testing.T) {
 }`
 
 	array := []struct {
-		Feild1 string `json:"feild1"`
+		Feild1 string `json:"feild1, ,omitempty"`
 	}{
 		{
 			Feild1: "field1value",
@@ -507,9 +507,9 @@ func TestArrayMappingWithStruct(t *testing.T) {
 	}
 
 	address := []struct {
-		Street  string `json:"street"`
-		Zipcode int    `json:"zipcode"`
-		State   string `json:"state"`
+		Street  string `json:"street,omitempty"`
+		Zipcode int    `json:"zipcode,omitempty"`
+		State   string `json:"state,omitempty"`
 		Array   interface{}
 	}{
 		{

--- a/data/path/path.go
+++ b/data/path/path.go
@@ -86,10 +86,9 @@ func getFieldValueByName(object interface{}, name string) (interface{}, error) {
 		for i := 0; i < typ.NumField(); i++ {
 			p := typ.Field(i)
 			if !p.Anonymous {
-				if p.Tag != "" && len(p.Tag) > 0 {
-					if name == p.Tag.Get("json") {
-						return val.FieldByName(typ.Field(i).Name).Interface(), nil
-					}
+				jsonTag := GetJsonTag(p)
+				if len(jsonTag) > 0 && name == jsonTag {
+					return val.FieldByName(typ.Field(i).Name).Interface(), nil
 				}
 			}
 		}
@@ -99,6 +98,17 @@ func getFieldValueByName(object interface{}, name string) (interface{}, error) {
 		return v.Interface(), nil
 	}
 	return nil, fmt.Errorf("unable to evaluate path: %s", name)
+}
+
+func GetJsonTag(t reflect.StructField) string {
+	if jsonTag := t.Tag.Get("json"); jsonTag != "" && jsonTag != "-" {
+		var commaIdx int
+		if commaIdx = strings.Index(jsonTag, ","); commaIdx < 0 {
+			commaIdx = len(jsonTag)
+		}
+		return jsonTag[:commaIdx]
+	}
+	return ""
 }
 
 func NormalizeFieldName(name string) string {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Cannot handle when a struct has json tag which has `omitempty` or `-`
**What is the new behavior?**
FIxed the issue to get only the field tag name rather than `omitempty` or `-`