### PR TITLE
Add GetSetting method to handle legacy activity

### DIFF
--- a/activity/legacy.go
+++ b/activity/legacy.go
@@ -56,4 +56,5 @@ type LegacyCtx interface {
 
 	// GetOutput gets the value of the specified output attribute
 	GetOutput(name string) interface{}
+	GetSetting(name string) (value interface{}, exists bool)
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
There is no way to get legacy activity setting fields.
**What is the new behavior?**
Add GetSetting method in legacycxt