### PR TITLE
Fix an issue regarding array mapping accessing scope

### DIFF
--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -454,13 +454,13 @@ func newLoopScope(arrayItem interface{}, indexName string, scope data.Scope) (da
 	if err != nil {
 		return nil, fmt.Errorf("convert array item data [%+v] to map failed, due to [%s]", arrayItem, err.Error())
 	}
-	if len(indexName) <= 0 {
-		return data.NewSimpleScope(mapData, scope), nil
-	} else {
-		values := mapData
-		values[indexName] = mapData
-		return data.NewSimpleScope(values, scope), nil
+	loopData := make(map[string]interface{})
+	loopData["_loop"] = mapData
+
+	if len(indexName) > 0 {
+		loopData[indexName] = mapData
 	}
+	return data.NewSimpleScope(loopData, scope), nil
 }
 
 func ToObjectMap(value interface{}) (map[string]interface{}, error) {

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -983,7 +983,7 @@ func TestArrayMappingWithFilterNested(t *testing.T) {
         "status": "=$loop.status",
         "categories": "=$loop.categories",
         "author": {
-          "@foreach($.authors, authorLoop, $loop.age > 45)": {
+          "@foreach($loop.authors, authorLoop, $loop.age > 45)": {
             "firstName": "=$loop.firstName",
             "lastName": "=$loop.lastName",
             "age": "=$loop.age"

--- a/data/resolve/loop.go
+++ b/data/resolve/loop.go
@@ -17,17 +17,19 @@ func (*LoopResolver) GetResolverInfo() *ResolverInfo {
 
 //LoopResolver Loop Resolver $Loop[item]
 func (*LoopResolver) Resolve(scope data.Scope, item string, field string) (interface{}, error) {
+	var value interface{}
+	var exist bool
 	if item == "" {
-		v, exist := scope.GetValue(field)
+		value, exist = scope.GetValue("_loop")
 		if !exist {
 			return nil, fmt.Errorf("failed to resolve current Loop: '%s', ensure that Loop is configured in the application", field)
 		}
-		return v, nil
 	} else {
-		value, exists := scope.GetValue(item)
-		if !exists {
+		value, exist = scope.GetValue(item)
+		if !exist {
 			return nil, fmt.Errorf("failed to resolve Loop: '%s', ensure that Loop is configured in the application", item)
 		}
-		return path.GetValue(value, "."+field)
 	}
+	return path.GetValue(value, "."+field)
+
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
We just add array element data into current data scope when means we still can use $.xxx to get it.
**What is the new behavior?**
We should only allow using $loop.xxx to access array mapping data otherwise it will have an issue when use array mapping in the trigger to flow or flow to trigger mapping