### PR TITLE
initial shared connection support

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -64,10 +64,10 @@ func New(config *Config, runner action.Runner, options ...Option) (*App, error) 
 	}
 
 	for id, config := range config.Connections {
-		f := connection.GetManagerFactory(config.Type)
+		f := connection.GetManagerFactory(config.Ref)
 
 		if f == nil {
-			return nil, fmt.Errorf("connection factory for type '%s' not registered", config.Type)
+			return nil, fmt.Errorf("connection factory '%s' not registered", config.Ref)
 		}
 
 		//todo resolve settings values

--- a/app/app.go
+++ b/app/app.go
@@ -65,6 +65,11 @@ func New(config *Config, runner action.Runner, options ...Option) (*App, error) 
 
 	for id, config := range config.Connections {
 		f := connection.GetManagerFactory(config.Type)
+
+		if f == nil {
+			return nil, fmt.Errorf("connection factory for type '%s' not registered", config.Type)
+		}
+
 		//todo resolve settings values
 		cm, err := f.NewManager(config.Settings)
 		if err != nil {

--- a/app/config.go
+++ b/app/config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/project-flogo/core/app/resource"
 	"github.com/project-flogo/core/data"
 	"github.com/project-flogo/core/data/schema"
+	"github.com/project-flogo/core/support/connection"
 	"github.com/project-flogo/core/trigger"
 )
 
@@ -16,11 +17,12 @@ type Config struct {
 	Description string `json:"description"`
 	AppModel    string `json:"appModel"`
 
-	Imports    []string               `json:"imports,omitempty"`
-	Properties []*data.Attribute      `json:"properties,omitempty"`
-	Channels   []string               `json:"channels,omitempty"`
-	Triggers   []*trigger.Config      `json:"triggers"`
-	Resources  []*resource.Config     `json:"resources,omitempty"`
-	Actions    []*action.Config       `json:"actions,omitempty"`
-	Schemas    map[string]*schema.Def `json:"schemas,omitempty"`
+	Imports     []string                      `json:"imports,omitempty"`
+	Properties  []*data.Attribute             `json:"properties,omitempty"`
+	Channels    []string                      `json:"channels,omitempty"`
+	Triggers    []*trigger.Config             `json:"triggers"`
+	Resources   []*resource.Config            `json:"resources,omitempty"`
+	Actions     []*action.Config              `json:"actions,omitempty"`
+	Schemas     map[string]*schema.Def        `json:"schemas,omitempty"`
+	Connections map[string]*connection.Config `json:"connections,omitempty"`
 }

--- a/data/coerce/coercion.go
+++ b/data/coerce/coercion.go
@@ -50,10 +50,11 @@ func ToType(value interface{}, dataType data.Type) (interface{}, error) {
 		coerced, err = ToObject(value)
 	case data.TypeArray:
 		coerced, err = ToArrayIfNecessary(value)
+	case data.TypeConnection:
+		coerced, err = ToConnection(value)
 	case data.TypeUnknown:
 		coerced = value
 	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/data/coerce/connection.go
+++ b/data/coerce/connection.go
@@ -1,0 +1,51 @@
+package coerce
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/project-flogo/core/support/connection"
+)
+
+func ToConnection(val interface{}) (connection.Manager, error) {
+
+	switch t := val.(type) {
+	case string:
+		if strings.HasPrefix(t, "conn://") {
+			id := t[7:]
+			cm := connection.GetManager(id)
+
+			if cm == nil {
+				return nil, fmt.Errorf("connection with id '%s' not configured", t)
+			}
+
+			return cm, nil
+		} else {
+			cc := &connection.Config{}
+			if t != "" {
+				err := json.Unmarshal([]byte(t), cc)
+				if err != nil {
+					return nil, fmt.Errorf("'%s' is not a valid connection config", t)
+				}
+			}
+
+			f := connection.GetManagerFactory(cc.Ref)
+			if f == nil {
+				return nil, fmt.Errorf("no connection factory registered for '%s'", cc.Ref)
+			}
+
+			cm, err := f.NewManager(cc.Settings)
+			if err != nil {
+				return nil, err
+			}
+
+			return cm, nil
+		}
+	case connection.Manager:
+		return t, nil
+	default:
+		// try to create config from map[string]interface{}
+		return nil, fmt.Errorf("unable to create connection from '%#v'", val)
+	}
+}

--- a/data/types.go
+++ b/data/types.go
@@ -33,6 +33,9 @@ const (
 	TypeParams // map[string]string
 	TypeArray  // []interface{}
 	TypeMap    // map[interface{}]interface{}
+
+	//Special Type
+	TypeConnection
 )
 
 var types = [...]string{
@@ -50,6 +53,7 @@ var types = [...]string{
 	"params",
 	"array",
 	"map",
+	"connection",
 }
 
 func (t Type) String() string {
@@ -76,6 +80,7 @@ var names = map[Type]string{
 	TypeParams:  "TypeParams",
 	TypeArray:   "TypeArray",
 	TypeMap:     "TypeMap",
+	TypeConnection: "TypeConnection",
 }
 
 // Name returns the name of the type
@@ -113,6 +118,8 @@ func ToTypeEnum(typeStr string) (Type, error) {
 		return TypeArray, nil
 	case "map":
 		return TypeMap, nil
+	case "connection":
+		return TypeConnection, nil
 	default:
 		return TypeUnknown, errors.New("unknown type: " + typeStr)
 	}

--- a/support/connection/config.go
+++ b/support/connection/config.go
@@ -1,6 +1,6 @@
 package connection
 
 type Config struct {
-	Type     string            `json:"ref,omitempty"`
-	Settings map[string]string `json:"settings,omitempty"`
+	Ref      string                 `json:"ref,omitempty"`
+	Settings map[string]interface{} `json:"settings,omitempty"`
 }

--- a/support/connection/config.go
+++ b/support/connection/config.go
@@ -1,0 +1,6 @@
+package connection
+
+type Config struct {
+	Type     string            `json:"ref,omitempty"`
+	Settings map[string]string `json:"settings,omitempty"`
+}

--- a/support/connection/manager.go
+++ b/support/connection/manager.go
@@ -1,12 +1,16 @@
 package connection
 
 type Manager interface {
+	Type()
+
 	GetConnection() interface{}
 
 	//ReleaseConnection(connection interface{})
 }
 
 type ManagerFactory interface {
-	NewManager(settings map[string]string) (Manager, error)
+	Type()
+
+	NewManager(settings map[string]interface{}) (Manager, error)
 }
 

--- a/support/connection/manager.go
+++ b/support/connection/manager.go
@@ -1,0 +1,12 @@
+package connection
+
+type Manager interface {
+	GetConnection() interface{}
+
+	//ReleaseConnection(connection interface{})
+}
+
+type ManagerFactory interface {
+	NewManager(settings map[string]string) (Manager, error)
+}
+

--- a/support/connection/registry.go
+++ b/support/connection/registry.go
@@ -62,29 +62,11 @@ func GetManager(id string) Manager {
 	return managers[id]
 }
 
-func StartManagers() error {
+func Managers() map[string]Manager {
+	ret := make(map[string]Manager,len(managers) )
 	for id, manager := range managers {
-		if m, ok:= manager.(managed.Managed); ok {
-			err := m.Start()
-			if err != nil {
-				return fmt.Errorf("unable to start connection manager for '%s': %v", id, err)
-			}
-		}
+		ret[id] = manager
 	}
 
-	return nil
-}
-
-func StopManagers() []error {
-	var errors []error
-	for id, manager := range managers {
-		if m, ok:= manager.(managed.Managed); ok {
-			err := m.Stop()
-			if err != nil {
-				errors = append(errors, fmt.Errorf("unable to start connection manager for '%s': %v", id, err))
-			}
-		}
-	}
-
-	return errors
+	return ret
 }

--- a/support/connection/registry.go
+++ b/support/connection/registry.go
@@ -1,0 +1,90 @@
+package connection
+
+import (
+	"fmt"
+
+	"github.com/project-flogo/core/support/managed"
+	"github.com/project-flogo/core/support/log"
+)
+
+var (
+	managerFactories = make(map[string]ManagerFactory)
+	managers = make(map[string]Manager)
+)
+
+func RegisterManagerFactory(connectionType string, factory ManagerFactory) error {
+
+	if connectionType == "" {
+		return fmt.Errorf("'connectionType' must be specified when registering")
+	}
+
+	if factory == nil {
+		return fmt.Errorf("cannot register with 'nil' manager factory")
+	}
+
+	if _, dup := managerFactories[connectionType]; dup {
+		return fmt.Errorf("manager factory already registered for type: %s", connectionType)
+	}
+
+	log.RootLogger().Debugf("Registering manager factory for type: %s", connectionType)
+
+	managerFactories[connectionType] = factory
+
+	return nil
+}
+
+func GetManagerFactory(id string) ManagerFactory {
+	return managerFactories[id]
+}
+
+func RegisterManager(connectionId string, manager Manager) error {
+
+	if connectionId == "" {
+		return fmt.Errorf("'id' must be specified when registering")
+	}
+
+	if manager == nil {
+		return fmt.Errorf("cannot register with 'nil' manager")
+	}
+
+	if _, dup := managers[connectionId]; dup {
+		return fmt.Errorf("manager already registered: %s", connectionId)
+	}
+
+	log.RootLogger().Debugf("Registering manager: %s", connectionId)
+
+	managers[connectionId] = manager
+
+	return nil
+}
+
+func GetManager(id string) Manager {
+	return managers[id]
+}
+
+func StartManagers() error {
+	for id, manager := range managers {
+		if m, ok:= manager.(managed.Managed); ok {
+			err := m.Start()
+			if err != nil {
+				return fmt.Errorf("unable to start connection manager for '%s': %v", id, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func StopManagers() []error {
+	var errors []error
+	for id, manager := range managers {
+		if m, ok:= manager.(managed.Managed); ok {
+			err := m.Stop()
+			if err != nil {
+				errors = append(errors, fmt.Errorf("unable to start connection manager for '%s': %v", id, err))
+			}
+		}
+	}
+
+	return errors
+}

--- a/support/connection/registry.go
+++ b/support/connection/registry.go
@@ -2,8 +2,8 @@ package connection
 
 import (
 	"fmt"
+	"github.com/project-flogo/core/support"
 
-	"github.com/project-flogo/core/support/managed"
 	"github.com/project-flogo/core/support/log"
 )
 
@@ -12,29 +12,27 @@ var (
 	managers = make(map[string]Manager)
 )
 
-func RegisterManagerFactory(connectionType string, factory ManagerFactory) error {
-
-	if connectionType == "" {
-		return fmt.Errorf("'connectionType' must be specified when registering")
-	}
+func RegisterManagerFactory(factory ManagerFactory) error {
 
 	if factory == nil {
 		return fmt.Errorf("cannot register with 'nil' manager factory")
 	}
 
-	if _, dup := managerFactories[connectionType]; dup {
-		return fmt.Errorf("manager factory already registered for type: %s", connectionType)
+	ref := support.GetRef(factory)
+
+	if _, dup := managerFactories[ref]; dup {
+		return fmt.Errorf("manager factory already registered: %s", ref)
 	}
 
-	log.RootLogger().Debugf("Registering manager factory for type: %s", connectionType)
+	managerFactories[ref] = factory
 
-	managerFactories[connectionType] = factory
+	log.RootLogger().Debugf("Registering '%s' manager factory: %s", factory.Type, ref )
 
 	return nil
 }
 
-func GetManagerFactory(id string) ManagerFactory {
-	return managerFactories[id]
+func GetManagerFactory(ref string) ManagerFactory {
+	return managerFactories[ref]
 }
 
 func RegisterManager(connectionId string, manager Manager) error {

--- a/support/ssl/client.go
+++ b/support/ssl/client.go
@@ -3,6 +3,7 @@ package ssl
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/project-flogo/core/data/coerce"
@@ -99,7 +100,7 @@ func NewClientTLSConfig(config *Config) (*tls.Config, error) {
 	if config.CAFile != "" {
 		caCert, err := ioutil.ReadFile(config.CAFile)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to read CAfile '%s' : %v", config.CAFile, err)
 		}
 		caCertPool.AppendCertsFromPEM(caCert)
 	}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

This code allows shared connections to be configured in the app.  It assumes the following section is added to the flogo.json

```json
"connections": {
	"myrestConn": {
		"type": "http",
		"settings": {"":""}
	}
}
```
An activity that uses connection, just needs to expose a setting that indicates the id of the connection. And if this is set, it can use the connection.GetManager() to get the shared manager for it to use.  If an id isn't specified, it can create its own "local" manager to keep the client connection code consistent.  
