### PR TITLE
Added new retriable error to activity help PR #35 in project-flogo/flow

### DIFF
--- a/activity/error.go
+++ b/activity/error.go
@@ -6,10 +6,15 @@ type Error struct {
 	errorStr     string
 	errorCode    string
 	errorData    interface{}
+	retriable    bool
 }
 
 func NewError(errorText string, code string, errorData interface{}) *Error {
-	return &Error{errorStr: errorText, errorData: errorData, errorCode: code}
+	return &Error{errorStr: errorText, errorData: errorData, errorCode: code, retriable: false}
+}
+
+func NewRetriableError(errorText string, code string, errorData interface{}) *Error {
+	return &Error{errorStr: errorText, errorData: errorData, errorCode: code, retriable: true}
 }
 
 // Error implements error.Error()
@@ -35,4 +40,9 @@ func (e *Error) Data() interface{} {
 // Code returns any associated error code
 func (e *Error) Code() string {
 	return e.errorCode
+}
+
+// Retriable returns wether error is retriable
+func (e *Error) Retriable() bool {
+	return e.retriable
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently, activity contributions could only throw one type of activity error.
**What is the new behavior?**
Added a new constructor `NewRetriableError` that allows contributions to return a retriable error if the error could possibly be fixed on retry. For this task needs to be configured with `retryonerror`. More information about `retryonerror` is available at https://github.com/project-flogo/flow/pull/35
This feature is needed for the above PR to work.
