### PR TITLE
Emmitting application lifecycle events to listeners

### DIFF
--- a/engine/engineimpl.go
+++ b/engine/engineimpl.go
@@ -2,7 +2,9 @@ package engine
 
 import (
 	"fmt"
+
 	"github.com/project-flogo/core/data/property"
+
 	"strings"
 
 	"github.com/project-flogo/core/action"
@@ -168,8 +170,10 @@ func (e *engineImpl) Start() error {
 	logger.Info("Starting Application...")
 	err = e.flogoApp.Start()
 	if err != nil {
+		e.flogoApp.PostAppEvent(app.FAILED)
 		return err
 	}
+	e.flogoApp.PostAppEvent(app.STARTED)
 	logger.Info("Application Started")
 
 	if channels.Count() > 0 {
@@ -198,6 +202,7 @@ func (e *engineImpl) Stop() error {
 	logger.Info("Stopping Application...")
 	_ = e.flogoApp.Stop()
 	logger.Info("Application Stopped")
+	e.flogoApp.PostAppEvent(app.STOPPED)
 
 	//TODO temporarily add services
 	logger.Info("Stopping Services...")


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today listeners can not gather application events like started, failed or stopped. In certain scenarios, listener may want to initialize certain things based on application status. e.g. Datadog event listener wants to enable application tracer only after app is successfully started
**What is the new behavior?**
Added new event type **_appevent_** that listeners can subscriber to get application lifecycle events like Started, Stopped and Failed.