### PR TITLE
change to debug to avoid adding print statements before engine starting

### DIFF
--- a/support/trace/registry.go
+++ b/support/trace/registry.go
@@ -9,7 +9,7 @@ var tracer Tracer
 // RegisterTracer registers the configured tracer
 func RegisterTracer(t Tracer) error {
 	if !isTracerRegistered() {
-		log.RootLogger().Infof("Registering tracer: %s", t.Name())
+		log.RootLogger().Debugf("Registering tracer: %s", t.Name())
 		tracer = t
 	}
 	return nil


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[x] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
There are Info statements from `Register()` that get printed before engine starts as the implementations register the tracer at `init()`.
![image](https://user-images.githubusercontent.com/17915583/66349518-f07bc280-e90d-11e9-8387-8c37610a8b34.png)

**What is the new behavior?**
Changed level to debug and move any implementation logs to `managed.Start()`