### PR TITLE
Expose getOutput method to activity context

### DIFF
--- a/activity/context.go
+++ b/activity/context.go
@@ -19,11 +19,17 @@ type Context interface {
 	// GetInput gets the value of the specified input attribute
 	GetInput(name string) interface{}
 
+	// GetOutput gets the value of the specified output attribute
+	GetOutput(name string) interface{}
+
 	// SetOutput sets the value of the specified output attribute
 	SetOutput(name string, value interface{}) error
 
 	// GetInputObject gets all the activity input as the specified object.
 	GetInputObject(input data.StructValue) error
+
+	// GetOutputObject gets all the activity output as the specified object.
+	GetOutputObject(input data.StructValue) error
 
 	// SetOutputObject sets the activity output as the specified object.
 	SetOutputObject(output data.StructValue) error


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[*] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today, We cann't get the activity output from context.  And it is useful for some activity which requires to get output field value to do some work

FOr example Rest Invoke,  we want to expose the ability to let the user define response code/schema which part of the output.
**What is the new behavior?**

Expose GetOutput API to activity context