### PR TITLE
In case of optional mapping, null value is set to the field.

### DIFF
--- a/data/mapper/config.go
+++ b/data/mapper/config.go
@@ -8,6 +8,8 @@ import (
 const (
 	EnvMappingRelexed        = "FLOGO_MAPPING_RELAXED"
 	EnvMappingRelexedDefault = false
+	EnvMappingOmitNull        = "FLOGO_MAPPING_OMIT_NULL"
+	EnvMappingOmitNullDefault = false
 )
 
 func IsMappingRelaxed() bool {
@@ -16,5 +18,14 @@ func IsMappingRelaxed() bool {
 		return EnvMappingRelexedDefault
 	}
 	b, _ := strconv.ParseBool(relaxed)
+	return b
+}
+
+func OmitNull() bool {
+	omitNull := os.Getenv(EnvMappingOmitNull)
+	if len(omitNull) <= 0 {
+		return EnvMappingOmitNullDefault
+	}
+	b, _ := strconv.ParseBool(omitNull)
 	return b
 }

--- a/data/mapper/expr.go
+++ b/data/mapper/expr.go
@@ -72,7 +72,7 @@ func (m *ExprMapper) Apply(inputScope data.Scope) (map[string]interface{}, error
 		val, err := expr.Eval(inputScope)
 		if err != nil {
 			if IsMappingRelaxed() {
-				log.RootLogger().Warnf("expresson eval error; %s", err.Error())
+				log.RootLogger().Warnf("expression eval error; %s", err.Error())
 				//Skip value set.
 				continue
 			}

--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -389,11 +389,11 @@ func handleObject(targetValue map[string]interface{}, targetName string, source 
 		if err != nil {
 			return fmt.Errorf("eval expression failed %s", err.Error())
 		}
-		if fromValue != nil {
+		if fromValue != nil || OmitNull() == false {
 			targetValue[targetName] = fromValue
 		}
 	} else {
-		if source != nil {
+		if source != nil || OmitNull() == false {
 			targetValue[targetName] = source
 		}
 	}

--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -389,9 +389,13 @@ func handleObject(targetValue map[string]interface{}, targetName string, source 
 		if err != nil {
 			return fmt.Errorf("eval expression failed %s", err.Error())
 		}
-		targetValue[targetName] = fromValue
+		if fromValue != nil {
+			targetValue[targetName] = fromValue
+		}
 	} else {
-		targetValue[targetName] = source
+		if source != nil {
+			targetValue[targetName] = source
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #167 

**What is the current behavior?**
null value set to the optional field when the optional field's mapping is emty.
**What is the new behavior?**
WE should able to provide a way to omitted value for optional field
NULL field is omitted from the input object if the mapper value is not set.