### PR TITLE
Get value from struct while mapping ref has map key.

### DIFF
--- a/data/path/path.go
+++ b/data/path/path.go
@@ -53,7 +53,12 @@ func GetValue(value interface{}, path string) (interface{}, error) {
 		} else if paramsVal, ok := value.(map[string]string); ok {
 			newVal, newPath, err = getSetMapParamsValue(paramsVal, path, nil, false)
 		} else {
-			return nil, fmt.Errorf("unable to evaluate path: %s", path)
+			fieldName, npIdx := getMapKey(path[2:])
+			newVal, err = getFieldValueByName(value, fieldName)
+			if err != nil {
+				return nil, err
+			}
+			newPath = path[npIdx:]
 		}
 	} else if strings.HasPrefix(path, "[") {
 		newVal, newPath, err = getSetArrayValue(value, path, nil, false)

--- a/data/path/path_test.go
+++ b/data/path/path_test.go
@@ -303,3 +303,63 @@ func TestSetValue(t *testing.T) {
 	//assert.Nil(t, err)
 	//////todo check if map
 }
+
+func TestGetValueFromStruct(t *testing.T) {
+
+	type object struct {
+		ID     string  `json:"id"`
+		Name   string  `json:"name"`
+		TT     string  `json:"T!T"`
+		Nested *object `json:"Nest.Object"`
+	}
+
+	source := struct {
+		Object *object `json:"object"`
+	}{
+		Object: &object{
+			ID:   "1001",
+			Name: "flogo",
+			TT:   "t!tTesing",
+			Nested: &object{
+				ID:     "1001-2",
+				Name:   "flogo-2",
+				TT:     "ddddd",
+				Nested: nil,
+			},
+		},
+	}
+
+	skipMissing = true
+	tests := []struct {
+		Path  string
+		Value interface{}
+	}{
+		{
+			Path:  ".object.id",
+			Value: "1001",
+		},
+		{
+			Path:  ".object.name",
+			Value: "flogo",
+		},
+		{
+			Path:  `.object["T!T"]`,
+			Value: "t!tTesing",
+		},
+		{
+			Path:  `.object["Nest.Object"].id`,
+			Value: "1001-2",
+		},
+		{
+			Path:  `.object["Nest.Object"]["T!T"]`,
+			Value: "ddddd",
+		},
+	}
+
+	for _, test := range tests {
+		newVal, err := GetValue(source, test.Path)
+		assert.Nil(t, err)
+		assert.Equal(t, test.Value, newVal)
+	}
+
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today, we have an issue to get value from struct where it has map key such as `$activity[xxxx].output.object["T!T"]`
**What is the new behavior?**
