### PR TITLE
Publishing Trigger and handler events 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -340,11 +340,13 @@ func (a *App) Start() error {
 			statusInfo.Error = err
 			logger.Debugf("StackTrace: %s", debug.Stack())
 			failed = append(failed, id)
+			trigger.PostTriggerEvent(trigger.FAILED, id)
 		} else {
 			statusInfo.Status = managed.StatusStarted
 			//logger.Infof("Trigger [ %s ]: Started", id)
 			version := ""
 			logger.Debugf("Trigger [ %s ] has ref [ %s ] and version [ %s ]", id, trg.ref, version)
+			trigger.PostTriggerEvent(trigger.STARTED, id)
 		}
 	}
 
@@ -371,6 +373,7 @@ func (a *App) Stop() error {
 	for id, trg := range a.triggers {
 		_ = managed.Stop("Trigger [ "+id+" ]", trg.trg)
 		trg.status.Status = managed.StatusStopped
+		trigger.PostTriggerEvent(trigger.STOPPED, id)
 	}
 
 	logger.Info("Triggers Stopped")

--- a/app/instances.go
+++ b/app/instances.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/data/expression"
@@ -119,8 +120,9 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 		log.ChildLogger(logger, tConfig.Id)
 		initCtx := &initContext{logger: logger, handlers: make([]trigger.Handler, 0, len(tConfig.Handlers))}
 
+
 		//create handlers for that trigger and init
-		for _, hConfig := range tConfig.Handlers {
+		for index, hConfig := range tConfig.Handlers {
 
 			var acts []action.Action
 			var err error
@@ -180,6 +182,10 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 				}
 			}
 
+			if hConfig.Name == "" {
+				// Set name: <triggername>_handler<index+1> e.g. mytrigger_handler1
+				hConfig.Name = tConfig.Id + "_handler" + strconv.Itoa(index+1)
+			}
 			handler, err := trigger.NewHandler(hConfig, acts, mapperFactory, expressionFactory, runner)
 			if err != nil {
 				return nil, err

--- a/app/instances.go
+++ b/app/instances.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/data/expression"
@@ -122,7 +121,7 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 
 
 		//create handlers for that trigger and init
-		for index, hConfig := range tConfig.Handlers {
+		for _, hConfig := range tConfig.Handlers {
 
 			var acts []action.Action
 			var err error
@@ -182,10 +181,6 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 				}
 			}
 
-			if hConfig.Name == "" {
-				// Set name: <triggername>_handler<index+1> e.g. mytrigger_handler1
-				hConfig.Name = tConfig.Id + "_handler" + strconv.Itoa(index+1)
-			}
 			handler, err := trigger.NewHandler(hConfig, acts, mapperFactory, expressionFactory, runner)
 			if err != nil {
 				return nil, err

--- a/app/instances.go
+++ b/app/instances.go
@@ -119,7 +119,6 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 		log.ChildLogger(logger, tConfig.Id)
 		initCtx := &initContext{logger: logger, handlers: make([]trigger.Handler, 0, len(tConfig.Handlers))}
 
-
 		//create handlers for that trigger and init
 		for _, hConfig := range tConfig.Handlers {
 
@@ -188,11 +187,13 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 
 			initCtx.handlers = append(initCtx.handlers, handler)
 		}
-
+		trigger.PostTriggerEvent(trigger.INITIALIZING, tConfig.Id)
 		err = trg.Initialize(initCtx)
 		if err != nil {
+			trigger.PostTriggerEvent(trigger.INIT_FAILED, tConfig.Id)
 			return nil, err
 		}
+		trigger.PostTriggerEvent(trigger.INITIALIZED, tConfig.Id)
 
 		triggers[tConfig.Id] = &triggerWrapper{ref: ref, trg: trg, status: &managed.StatusInfo{Name: tConfig.Id}}
 	}

--- a/trigger/config.go
+++ b/trigger/config.go
@@ -2,6 +2,8 @@ package trigger
 
 import (
 	"encoding/json"
+	"strconv"
+
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/data/expression"
 	"github.com/project-flogo/core/data/metadata"
@@ -36,8 +38,13 @@ func (c *Config) FixUp(md *Metadata, resolver resolve.CompositeResolver) error {
 	}
 
 	// fix up handler settings
-	for _, hc := range c.Handlers {
+	for i, hc := range c.Handlers {
 		hc.parent = c
+
+		if hc.Name == "" {
+			// Set name: <triggername>_handler<index+1> e.g. mytrigger_handler1
+			hc.Name = c.Id + "_handler" + strconv.Itoa(i+1)
+		}
 
 		if len(hc.Settings) > 0 {
 			var err error

--- a/trigger/event.go
+++ b/trigger/event.go
@@ -19,7 +19,7 @@ const (
 type TriggerEvent interface {
 	// Name of trigger
 	Name() string
-	// Status of trigger. Valid values - STARTED, STOPPED, FAILED
+	// Status of trigger. Valid status - INITIALIZING, INITIALIZED, STARTED, STOPPED, FAILED
 	Status() Status
 }
 
@@ -41,9 +41,10 @@ type HandlerEvent interface {
 	TriggerName() string
 	// Name of the handler
 	HandlerName() string
-	// Status of handler. Valid values - INITIALIZED, STARTED, COMPLETED, FAILED
+	// Status of handler. Valid status - INITIALIZED, STARTED, COMPLETED, FAILED
 	Status() Status
-	// Handler specific tags set by the underlying implementation
+	// Handler specific tags set by the underlying implementation e.g. method and path by REST trigger handler or
+	// topic name by Kafka trigger handler. This is useful when peek view of trigger(and handlers) is desired.
 	Tags() map[string]string
 }
 

--- a/trigger/event.go
+++ b/trigger/event.go
@@ -5,7 +5,9 @@ import "github.com/project-flogo/core/engine/event"
 type Status string
 
 const (
+	INITIALIZING     = "Initializing"
 	INITIALIZED      = "Initialized"
+	INIT_FAILED      = "InitFailed"
 	STARTED          = "Started"
 	STOPPED          = "Stopped"
 	FAILED           = "Failed"
@@ -67,6 +69,10 @@ func (he handlerEvent) Status() Status {
 
 func (he handlerEvent) Tags() map[string]string {
 	return he.tags
+}
+
+func (s Status) String() string {
+	return string(s)
 }
 
 func PostTriggerEvent(tStatus Status, name string) {

--- a/trigger/event.go
+++ b/trigger/event.go
@@ -13,7 +13,6 @@ const (
 	FAILED           = "Failed"
 	COMPLETED        = "Completed"
 	TriggerEventType = "triggerevent"
-	HandlerEventType = "handlerevent"
 )
 
 // Trigger Event
@@ -84,8 +83,8 @@ func PostTriggerEvent(tStatus Status, name string) {
 
 // Publish handler event
 func PostHandlerEvent(hStatus Status, hName, tName string, hTags map[string]string) {
-	if event.HasListener(HandlerEventType) {
+	if event.HasListener(TriggerEventType) {
 		te := &handlerEvent{name: hName, triggerName: tName, status: hStatus, tags: hTags}
-		event.Post(HandlerEventType, te)
+		event.Post(TriggerEventType, te)
 	}
 }

--- a/trigger/event.go
+++ b/trigger/event.go
@@ -1,0 +1,85 @@
+package trigger
+
+import "github.com/project-flogo/core/engine/event"
+
+type Status string
+
+const (
+	INITIALIZED      = "Initialized"
+	STARTED          = "Started"
+	STOPPED          = "Stopped"
+	FAILED           = "Failed"
+	COMPLETED        = "Completed"
+	TriggerEventType = "triggerevent"
+	HandlerEventType = "handlerevent"
+)
+
+// Trigger Event
+type TriggerEvent interface {
+	// Name of trigger
+	Name() string
+	// Status of trigger. Valid values - STARTED, STOPPED, FAILED
+	Status() Status
+}
+
+type triggerEvent struct {
+	name   string
+	status Status
+}
+
+func (te triggerEvent) Name() string {
+	return te.name
+}
+
+func (te triggerEvent) Status() Status {
+	return te.status
+}
+
+type HandlerEvent interface {
+	// Name of trigger this handler belongs to
+	TriggerName() string
+	// Name of the handler
+	HandlerName() string
+	// Status of handler. Valid values - INITIALIZED, STARTED, COMPLETED, FAILED
+	Status() Status
+	// Handler specific tags set by the underlying implementation
+	Tags() map[string]string
+}
+
+type handlerEvent struct {
+	triggerName string
+	name        string
+	status      Status
+	tags        map[string]string
+}
+
+func (he handlerEvent) TriggerName() string {
+	return he.triggerName
+}
+
+func (he handlerEvent) HandlerName() string {
+	return he.name
+}
+
+func (he handlerEvent) Status() Status {
+	return he.status
+}
+
+func (he handlerEvent) Tags() map[string]string {
+	return he.tags
+}
+
+func PostTriggerEvent(tStatus Status, name string) {
+	if event.HasListener(TriggerEventType) {
+		te := &triggerEvent{name: name, status: tStatus}
+		event.Post(TriggerEventType, te)
+	}
+}
+
+// Publish handler event
+func PostHandlerEvent(hStatus Status, hName, tName string, hTags map[string]string) {
+	if event.HasListener(HandlerEventType) {
+		te := &handlerEvent{name: hName, triggerName: tName, status: hStatus, tags: hTags}
+		event.Post(HandlerEventType, te)
+	}
+}

--- a/trigger/handler.go
+++ b/trigger/handler.go
@@ -107,6 +107,8 @@ func (h *handlerImpl) Handle(ctx context.Context, triggerData interface{}) (map[
 
 	var triggerValues map[string]interface{}
 
+	PostHandlerEvent(STARTED, h.Name(), h.config.parent.Id, nil)
+
 	if triggerData == nil {
 		triggerValues = make(map[string]interface{})
 	} else if values, ok := triggerData.(map[string]interface{}); ok {
@@ -186,8 +188,11 @@ func (h *handlerImpl) Handle(ctx context.Context, triggerData interface{}) (map[
 
 	results, err := h.runner.RunAction(newCtx, act.act, inputMap)
 	if err != nil {
+		PostHandlerEvent(FAILED, h.Name(), h.config.parent.Id, nil)
 		return nil, err
 	}
+
+	PostHandlerEvent(COMPLETED, h.Name(), h.config.parent.Id, nil)
 
 	if act.actionOutputMapper != nil {
 		outScope := data.NewSimpleScope(results, nil)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Today, trigger related lifecycle events like start/stop/errors, total number of jobs started/faulted/completed (across all handlers) or handler related events like number of jobs started/faulted/completed are not published by the engine. 
**What is the new behavior?**
With this change, now event listeners can collect events related to trigger and handler.
