### PR TITLE
Object mapper optimize

### DIFF
--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -8,7 +8,6 @@ import (
 	"github.com/project-flogo/core/data/path"
 	"github.com/project-flogo/core/support/log"
 	"reflect"
-	"runtime/debug"
 	"strings"
 )
 
@@ -233,12 +232,6 @@ func newForeachExpr(foreachpath string, exprF expression.Factory) (*foreachExpr,
 }
 
 func (obj *ObjectMapper) Eval(scope data.Scope) (value interface{}, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			objectMapperLog.Error("%+v", r)
-			objectMapperLog.Debugf("StackTrace: %s", debug.Stack())
-		}
-	}()
 	if obj.foreach != nil {
 		return obj.foreach.Eval(scope)
 	} else if obj.literalArray != nil {

--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -99,11 +99,11 @@ type foreachExpr struct {
 	filterExpr expression.Expr
 	// fields
 	fields map[string]expression.Expr
-	//Use to assin
+	//Use to assign value
 	assign expression.Expr
 }
 
-// assignAllExpr uses to indicate it is assign all expression.
+// assignAllExpr uses to indicate it is assign all.
 type assignAllExpr struct {
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[*] Other... Please describe: Object mapper optimization because of performance issue.
```

**Fixes**: #

**What is the current behavior?**
Today we parse expression inside object mapper when running object mapper at runtime which causes performance bad

**What is the new behavior?**
Now we do parse expression inside expression at engine startup and runtime just execute it(Eval)


See benchmark improve.
```
Before
BenchmarkObj-12  100000	  17260 ns/op	   11648 B/op	  136 allocs/op

After:
BenchmarkObj-12   300000  3682 ns/op	    2472 B/op	   32 allocs/op
```

We can see which improve much better.