### PR TITLE
add support for setting event data from handler

### DIFF
--- a/trigger/event.go
+++ b/trigger/event.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"context"
+
 	"github.com/project-flogo/core/engine/event"
 )
 
@@ -101,6 +102,7 @@ type HandlerEventConfig interface {
 }
 
 type ctxEDKeyType int
+
 var ctxEDKey ctxEDKeyType
 
 // NewContextWithEventData add event data to a new child context.  This event data will be

--- a/trigger/event.go
+++ b/trigger/event.go
@@ -93,14 +93,18 @@ func PostHandlerEvent(hStatus Status, hName, tName string, data map[string]strin
 	}
 }
 
+// HandlerEventConfig is an interface that can be used to set the default event data that is
+// used in handler events
 type HandlerEventConfig interface {
+	// SetDefaultEventData sets the default event data to use for a handler
 	SetDefaultEventData(data map[string]string)
 }
 
 type ctxEDKeyType int
 var ctxEDKey ctxEDKeyType
 
-// NewContextWithEventData add the event data to a new child context
+// NewContextWithEventData add event data to a new child context.  This event data will be
+// associated handler events.
 func NewContextWithEventData(parentCtx context.Context, data map[string]string) context.Context {
 	if data != nil {
 		return context.WithValue(parentCtx, ctxEDKey, data)

--- a/trigger/event.go
+++ b/trigger/event.go
@@ -105,7 +105,7 @@ var ctxEDKey ctxEDKeyType
 
 // NewContextWithEventData add event data to a new child context.  This event data will be
 // associated handler events.
-func NewContextWithEventData(parentCtx context.Context, data map[string]string) context.Context {
+func AppendEventDataToContext(parentCtx context.Context, data map[string]string) context.Context {
 	if data != nil {
 		return context.WithValue(parentCtx, ctxEDKey, data)
 	}

--- a/trigger/handler.go
+++ b/trigger/handler.go
@@ -32,9 +32,9 @@ type actImpl struct {
 }
 
 type handlerImpl struct {
-	runner action.Runner
-	config *HandlerConfig
-	acts   []actImpl
+	runner    action.Runner
+	config    *HandlerConfig
+	acts      []actImpl
 	eventData map[string]string
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```
The following can be used to attach event data to a context.  This would be used when creating the context that is passed when a handler is invoked.  That data will added to the handler's events.
```
NewContextWithEventData(parentCtx context.Context, data map[string]string) 
```
The `HandlerEventConfig` interface is implemented by handlerImpl.  It can be used when processing handlers in a trigger's `Initialize` to set the default event data to attach to the handler's events.
