### PR TITLE
new loop scope only when there is filter for assign all case.

### DIFF
--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -343,16 +343,20 @@ func (f *foreachExpr) handleAssign(sourceArray []interface{}, inputScope data.Sc
 	switch f.assign.(type) {
 	case *assignAllExpr:
 		for _, sourceValue := range sourceArray {
-			var err error
-			inputScope, err = newLoopScope(sourceValue, f.scopeName, inputScope)
-			if err != nil {
-				return nil, err
-			}
-			passFilter, err := f.Filter(inputScope)
-			if err != nil {
-				return nil, err
-			}
-			if passFilter {
+			if f.filterExpr != nil {
+				var err error
+				inputScope, err = newLoopScope(sourceValue, f.scopeName, inputScope)
+				if err != nil {
+					return nil, err
+				}
+				passFilter, err := f.Filter(inputScope)
+				if err != nil {
+					return nil, err
+				}
+				if passFilter {
+					targetValues = append(targetValues, sourceValue)
+				}
+			} else {
 				targetValues = append(targetValues, sourceValue)
 			}
 		}

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -1183,6 +1183,49 @@ func TestArrayMappingWithFilterAndUpdate(t *testing.T) {
 	assert.Equal(t, "Testing", arr.(map[string]interface{})["books"].([]interface{})[0].(map[string]interface{})["status"])
 }
 
+func TestLiteralAssign(t *testing.T) {
+	mappingValue := `{
+   "mapping":{
+      "books":{
+		"authors":{
+			"@foreach($.books[0].authors, index)":{
+			"=":"$loop"
+  }	
+         }
+      }
+   }
+}`
+
+	arrayData := `[
+  {
+    "title": "Android",
+    "isbn": "1933988673",
+    "pageCount": 416,
+    "publishedDate": { "$date": "2009-04-01T00:00:00.000-0700" },
+    "status": "PUBLISH",
+    "authors": ["W. Frank Ableson", "Charlie Collins", "Robi Sen"],
+    "categories": ["Open Source", "Mobile"]
+  }
+  ]`
+
+	arrayMapping := make(map[string]interface{})
+	err := json.Unmarshal([]byte(mappingValue), &arrayMapping)
+	assert.Nil(t, err)
+	assert.False(t, IsLiteral(arrayMapping))
+	mappings := map[string]interface{}{"store": arrayMapping}
+	factory := NewFactory(resolver)
+	mapper, err := factory.NewMapper(mappings)
+	assert.Nil(t, err)
+
+	attrs := map[string]interface{}{"books": arrayData}
+	scope := data.NewSimpleScope(attrs, nil)
+	results, err := mapper.Apply(scope)
+	assert.Nil(t, err)
+
+	arr := results["store"]
+	assert.Equal(t, "W. Frank Ableson", arr.(map[string]interface{})["books"].(map[string]interface{})["authors"].([]interface{})[0])
+}
+
 func BenchmarkObj(b *testing.B) {
 
 	mappingValue := `{


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #199 

**What is the current behavior?**
Assume the source data is books and books have more than one author. authors are a string array. Now we want to assign this string array to another string array using below mapping

```
{
  "mapping": {
    "books": {
      "authors": {
        "@foreach($.books[0].authors, index)": {
          "=": "$loop"
        }
      }
    }
  }
}
```
Today it will fail say cannot convert string to map.

**What is the new behavior?**

Fixed it and it able to handle now.
