### PR TITLE
configure event queue size from env var

### DIFF
--- a/engine/envconfig.go
+++ b/engine/envconfig.go
@@ -24,8 +24,12 @@ const (
 	DefaultRunnerType        = ValueRunnerTypePooled
 	EnvKeyRunnerWorkers      = "FLOGO_RUNNER_WORKERS"
 	DefaultRunnerWorkers     = 5
-	EnvKeyRunnerQueueSize    = "FLOGO_RUNNER_QUEUE"
-	DefaultRunnerQueueSize   = 50
+
+	//Deprecated
+	EnvKeyRunnerQueueSizeLegacy = "FLOGO_RUNNER_QUEUE"
+
+	EnvKeyRunnerQueueSize  = "FLOGO_RUNNER_QUEUE_SIZE"
+	DefaultRunnerQueueSize = 50
 
 	EnvAppPropertyResolvers   = "FLOGO_APP_PROP_RESOLVERS"
 	EnvEnableSchemaSupport    = "FLOGO_SCHEMA_SUPPORT"
@@ -212,6 +216,15 @@ func GetRunnerQueueSize() int {
 		i, err := strconv.Atoi(queueSizeEnv)
 		if err == nil {
 			queueSize = i
+		}
+	} else {
+		//For backward compatible.
+		legacyQueueSize := os.Getenv(EnvKeyRunnerQueueSizeLegacy)
+		if len(legacyQueueSize) > 0 {
+			i, err := strconv.Atoi(queueSizeEnv)
+			if err == nil {
+				queueSize = i
+			}
 		}
 	}
 	return queueSize

--- a/engine/event/env.go
+++ b/engine/event/env.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	EnvKeyEventQueues  = "FLOGO_EVENT_QUEUES"
-	DefaultEventQueues = 100
+	EnvKeyEventQueueSize  = "FLOGO_EVENT_QUEUE_SIZE"
+	DefaultEventQueueSize = 100
 
 	EnvKeyPublishAuditEvents  = "FLOGO_PUBLISH_AUDIT_EVENTS"
 	DefaultPublishAuditEvents = true
@@ -25,8 +25,8 @@ func PublishEventEnabled() bool {
 
 //GetEventQueues returns the number of queues to buffer events
 func GetEventQueues() int {
-	numQueues := DefaultEventQueues
-	queuesEnv := os.Getenv(EnvKeyEventQueues)
+	numQueues := DefaultEventQueueSize
+	queuesEnv := os.Getenv(EnvKeyEventQueueSize)
 	if len(queuesEnv) > 0 {
 		i, err := strconv.Atoi(queuesEnv)
 		if err == nil {

--- a/engine/event/env.go
+++ b/engine/event/env.go
@@ -24,7 +24,7 @@ func PublishEventEnabled() bool {
 }
 
 //GetEventQueues returns the number of queues to buffer events
-func GetEventQueues() int {
+func GetEventQueueSize() int {
 	numQueues := DefaultEventQueueSize
 	queuesEnv := os.Getenv(EnvKeyEventQueueSize)
 	if len(queuesEnv) > 0 {

--- a/engine/event/env.go
+++ b/engine/event/env.go
@@ -1,0 +1,37 @@
+package event
+
+import (
+	"os"
+	"strconv"
+)
+
+const (
+	EnvKeyEventQueues  = "FLOGO_EVENT_QUEUES"
+	DefaultEventQueues = 100
+
+	EnvKeyPublishAuditEvents  = "FLOGO_PUBLISH_AUDIT_EVENTS"
+	DefaultPublishAuditEvents = true
+)
+
+// PublishEventEnabled indicate the publish event enabled or not
+func PublishEventEnabled() bool {
+	key := os.Getenv(EnvKeyPublishAuditEvents)
+	if len(key) > 0 {
+		publish, _ := strconv.ParseBool(key)
+		return publish
+	}
+	return DefaultPublishAuditEvents
+}
+
+//GetEventQueues returns the number of queues to buffer events
+func GetEventQueues() int {
+	numQueues := DefaultEventQueues
+	queuesEnv := os.Getenv(EnvKeyEventQueues)
+	if len(queuesEnv) > 0 {
+		i, err := strconv.Atoi(queuesEnv)
+		if err == nil {
+			numQueues = i
+		}
+	}
+	return numQueues
+}

--- a/engine/event/events.go
+++ b/engine/event/events.go
@@ -25,7 +25,7 @@ func (ec *Context) GetEventType() string {
 }
 
 // Buffered channel
-var eventQueue = make(chan *Context, 100)
+var eventQueue = make(chan *Context, GetEventQueues())
 
 // Puts event with given type and data on the channel
 func Post(eventType string, event interface{}) {

--- a/engine/event/events.go
+++ b/engine/event/events.go
@@ -25,7 +25,7 @@ func (ec *Context) GetEventType() string {
 }
 
 // Buffered channel
-var eventQueue = make(chan *Context, GetEventQueues())
+var eventQueue = make(chan *Context, GetEventQueueSize())
 
 // Puts event with given type and data on the channel
 func Post(eventType string, event interface{}) {

--- a/engine/event/publish.go
+++ b/engine/event/publish.go
@@ -1,17 +1,12 @@
 package event
 
 import (
-	"os"
-	"strconv"
-
 	"github.com/project-flogo/core/support/log"
 )
 
-const (
-	EnvPublishAuditEventsKey = "FLOGO_PUBLISH_AUDIT_EVENTS"
-)
+const ()
 
-var publishEventsEnabled = PublishEnabled()
+var publishEventsEnabled = PublishEventEnabled()
 var publisherRunning = false
 var shutdown = make(chan bool)
 
@@ -74,13 +69,4 @@ func publishEvent(evtCtx *Context) {
 	if ok {
 		emitter.Publish(evtCtx)
 	}
-}
-
-func PublishEnabled() bool {
-	key := os.Getenv(EnvPublishAuditEventsKey)
-	if len(key) > 0 {
-		publish, _ := strconv.ParseBool(key)
-		return publish
-	}
-	return true
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #209

**What is the current behavior?**
Today we hardcode event queue size to 100 which is not good. For high loading requests, the 100 queues might be the bottleneck.

**What is the new behavior?**
We should able to configure the value from env vars.