### PR TITLE
Improve error message when function or trigger not import in engine

### DIFF
--- a/app/instances.go
+++ b/app/instances.go
@@ -87,7 +87,7 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 			var ok bool
 			ref, ok = support.GetAliasRef("trigger", tConfig.Ref)
 			if !ok {
-				return nil, fmt.Errorf("trigger [%s]'s 'ref' [%s] not imported", tConfig.Id, tConfig.Ref)
+				return nil, fmt.Errorf("incompatible app engine, the app using the trigger [%s] with ref [%s] is not installed", tConfig.Id, tConfig.Ref)
 			}
 		}
 

--- a/app/instances.go
+++ b/app/instances.go
@@ -87,7 +87,7 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 			var ok bool
 			ref, ok = support.GetAliasRef("trigger", tConfig.Ref)
 			if !ok {
-				return nil, fmt.Errorf("incompatible app engine, the app using the trigger [%s] with ref [%s] is not installed", tConfig.Id, tConfig.Ref)
+				return nil, fmt.Errorf("unable to start trigger [%s], ref alias '%s' has no corresponding installed trigger", tConfig.Id, tConfig.Ref)
 			}
 		}
 

--- a/data/expression/script/gocc/ast/function.go
+++ b/data/expression/script/gocc/ast/function.go
@@ -20,7 +20,7 @@ func NewFuncExpr(name interface{}, args interface{}) (Expr, error) {
 
 	f := function.Get(funcName)
 	if f == nil {
-		return nil, fmt.Errorf("incompatible app engine, the app using the function [%s] which is not installed", funcName)
+		return nil, fmt.Errorf("unable to parse expression, function [%s] is not installed", funcName)
 	}
 	fe := &funcExpr{f: f}
 

--- a/data/expression/script/gocc/ast/function.go
+++ b/data/expression/script/gocc/ast/function.go
@@ -20,7 +20,7 @@ func NewFuncExpr(name interface{}, args interface{}) (Expr, error) {
 
 	f := function.Get(funcName)
 	if f == nil {
-		return nil, fmt.Errorf("incompatible app engine, this app using the function [%s] which is not installed", funcName)
+		return nil, fmt.Errorf("incompatible app engine, the app using the function [%s] which is not installed", funcName)
 	}
 	fe := &funcExpr{f: f}
 

--- a/data/expression/script/gocc/ast/function.go
+++ b/data/expression/script/gocc/ast/function.go
@@ -20,7 +20,7 @@ func NewFuncExpr(name interface{}, args interface{}) (Expr, error) {
 
 	f := function.Get(funcName)
 	if f == nil {
-		return nil, fmt.Errorf("function '%s' not registered", funcName)
+		return nil, fmt.Errorf("incompatible app engine, this app using the function [%s] which is not installed", funcName)
 	}
 	fe := &funcExpr{f: f}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[*] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Error message for trigger not import, today
```
 Failed to create engine: trigger [timer]'s 'ref' [#timer] not imported

```
**What is the new behavior?**

Today's error message which not very clear for user to know what happens. 
Change to below 
```
  Failed to create engine: incompatible app engine, the app using the trigger [timer] with ref [#timer] is not installed

```