### PR TITLE
Handle json.Number type in expression

### DIFF
--- a/data/expression/script/gocc/ast/arithmetic.go
+++ b/data/expression/script/gocc/ast/arithmetic.go
@@ -1,8 +1,10 @@
 package ast
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/project-flogo/core/data"
 	"github.com/project-flogo/core/data/coerce"
@@ -68,8 +70,15 @@ func (e *arithAddExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li + ri, nil
 		}
+
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li + ri, nil
+		}
+
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
 			return lf + rf, nil
@@ -77,6 +86,26 @@ func (e *arithAddExpr) Eval(scope data.Scope) (interface{}, error) {
 	case string:
 		rs, _ := coerce.ToString(rv)
 		return le + rs, nil
+	case json.Number:
+		if strings.Contains(le.String(), ".") {
+			lf, _ := le.Float64()
+			rf, err := coerce.ToFloat64(rv)
+			if err != nil {
+				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(lv).String())
+			}
+			fmt.Println(lf)
+			fmt.Println(rf)
+
+			fmt.Println(lf + rf)
+			return lf + rf, nil
+		} else {
+			lf, _ := le.Int64()
+			rf, err := coerce.ToInt64(rv)
+			if err != nil {
+				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(lv).String())
+			}
+			return lf + rf, nil
+		}
 	}
 
 	if rt == reflect.String {
@@ -102,38 +131,72 @@ func (e *arithSubExpr) Init(resolver resolve.CompositeResolver, root bool) error
 }
 
 func (e *arithSubExpr) Eval(scope data.Scope) (interface{}, error) {
-	lv, rv, err := evalLR(e.left, e.right, scope)
+	leftValue, rightValue, err := evalLR(e.left, e.right, scope)
 	if err != nil {
 		return nil, err
 	}
 
-	if lv == nil || rv == nil {
+	if leftValue == nil || rightValue == nil {
 		//todo validate
-		return nil, fmt.Errorf("cannot subtract %v from %v", rv, lv)
+		return nil, fmt.Errorf("cannot subtract %v from %v", rightValue, leftValue)
 	}
 
-	rt := reflect.TypeOf(rv).Kind()
-	switch lv.(type) {
+	rt := reflect.TypeOf(rightValue).Kind()
+	switch le := leftValue.(type) {
 	case int, int32, int64:
 		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 {
-			li, _ := coerce.ToInt(lv) //todo should this be Int64
-			ri, _ := coerce.ToInt(rv) //todo should this be Int64
+			li, _ := coerce.ToInt(leftValue)  //todo should this be Int64
+			ri, _ := coerce.ToInt(rightValue) //todo should this be Int64
 			return li - ri, nil
 		}
 		if rt == reflect.Float32 || rt == reflect.Float64 {
-			li, _ := coerce.ToFloat64(lv)
-			ri, _ := coerce.ToFloat64(rv)
+			li, _ := coerce.ToFloat64(leftValue)
+			ri, _ := coerce.ToFloat64(rightValue)
+			return li - ri, nil
+		}
+
+		if isJsonNumber(rightValue) {
+			li, _ := coerce.ToInt64(leftValue)
+			ri, _ := coerce.ToInt64(rightValue)
 			return li - ri, nil
 		}
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
-			lf, _ := coerce.ToFloat64(lv)
-			rf, _ := coerce.ToFloat64(rv)
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rightValue) {
+			lf, _ := coerce.ToFloat64(leftValue)
+			rf, _ := coerce.ToFloat64(rightValue)
+			return lf - rf, nil
+		}
+
+	case json.Number:
+		if strings.Contains(le.String(), ".") {
+			lf, _ := le.Float64()
+			rf, err := coerce.ToFloat64(rightValue)
+			if err != nil {
+				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rightValue).String(), reflect.TypeOf(leftValue).String())
+			}
+			return lf - rf, nil
+		} else {
+			lf, _ := le.Int64()
+			rf, err := coerce.ToInt64(rightValue)
+			if err != nil {
+				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rightValue).String(), reflect.TypeOf(leftValue).String())
+			}
 			return lf - rf, nil
 		}
 	}
 
-	return false, fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(lv).String())
+	return false, fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rightValue).String(), reflect.TypeOf(leftValue).String())
+}
+
+func isJsonNumber(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	switch v.(type) {
+	case json.Number:
+		return true
+	}
+	return false
 }
 
 type arithMulExpr struct {
@@ -161,7 +224,7 @@ func (e *arithMulExpr) Eval(scope data.Scope) (interface{}, error) {
 	}
 
 	rt := reflect.TypeOf(rv).Kind()
-	switch lv.(type) {
+	switch le := lv.(type) {
 	case int, int32, int64:
 		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 {
 			li, _ := coerce.ToInt(lv) //todo should this be Int64
@@ -173,10 +236,31 @@ func (e *arithMulExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li * ri, nil
 		}
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li * ri, nil
+		}
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
+			return lf * rf, nil
+		}
+	case json.Number:
+		if strings.Contains(le.String(), ".") {
+			lf, _ := le.Float64()
+			rf, err := coerce.ToFloat64(rv)
+			if err != nil {
+				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(le).String())
+			}
+			return lf * rf, nil
+		} else {
+			lf, _ := le.Int64()
+			rf, err := coerce.ToInt64(rv)
+			if err != nil {
+				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(le).String())
+			}
 			return lf * rf, nil
 		}
 	}
@@ -209,7 +293,7 @@ func (e *arithDivExpr) Eval(scope data.Scope) (interface{}, error) {
 	}
 
 	rt := reflect.TypeOf(rv).Kind()
-	switch lv.(type) {
+	switch le := lv.(type) {
 	case int, int32, int64:
 		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 {
 			li, _ := coerce.ToInt(lv) //todo should this be Int64
@@ -221,10 +305,33 @@ func (e *arithDivExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li / ri, nil
 		}
+
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li / ri, nil
+		}
+
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
+			return lf / rf, nil
+		}
+	case json.Number:
+		if strings.Contains(le.String(), ".") {
+			lf, _ := le.Float64()
+			rf, err := coerce.ToFloat64(rv)
+			if err != nil {
+				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(le).String())
+			}
+			return lf / rf, nil
+		} else {
+			lf, _ := le.Int64()
+			rf, err := coerce.ToInt64(rv)
+			if err != nil {
+				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(le).String())
+			}
 			return lf / rf, nil
 		}
 	}
@@ -257,7 +364,7 @@ func (e *arithModExpr) Eval(scope data.Scope) (interface{}, error) {
 	}
 
 	rt := reflect.TypeOf(rv).Kind()
-	switch lv.(type) {
+	switch le := lv.(type) {
 	case int, int32, int64:
 		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 {
 			li, _ := coerce.ToInt(lv) //todo should this be Int64
@@ -269,12 +376,24 @@ func (e *arithModExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToInt(rv) //todo should this be Int64
 			return li % ri, nil
 		}
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li % ri, nil
+		}
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			li, _ := coerce.ToInt(lv) //todo should this be Int64
 			ri, _ := coerce.ToInt(rv) //todo should this be Int64
 			return li % ri, nil
 		}
+	case json.Number:
+		lf, _ := le.Int64()
+		rf, err := coerce.ToInt64(rv)
+		if err != nil {
+			fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(le).String())
+		}
+		return lf % rf, nil
 	}
 
 	return false, fmt.Errorf("cannot mod %s with %s", reflect.TypeOf(lv).String(), reflect.TypeOf(rv).String())

--- a/data/expression/script/gocc/ast/arithmetic.go
+++ b/data/expression/script/gocc/ast/arithmetic.go
@@ -93,10 +93,6 @@ func (e *arithAddExpr) Eval(scope data.Scope) (interface{}, error) {
 			if err != nil {
 				fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rv).String(), reflect.TypeOf(lv).String())
 			}
-			fmt.Println(lf)
-			fmt.Println(rf)
-
-			fmt.Println(lf + rf)
 			return lf + rf, nil
 		} else {
 			lf, _ := le.Int64()
@@ -186,17 +182,6 @@ func (e *arithSubExpr) Eval(scope data.Scope) (interface{}, error) {
 	}
 
 	return false, fmt.Errorf("cannot subtract %s from %s", reflect.TypeOf(rightValue).String(), reflect.TypeOf(leftValue).String())
-}
-
-func isJsonNumber(v interface{}) bool {
-	if v == nil {
-		return false
-	}
-	switch v.(type) {
-	case json.Number:
-		return true
-	}
-	return false
 }
 
 type arithMulExpr struct {
@@ -397,4 +382,15 @@ func (e *arithModExpr) Eval(scope data.Scope) (interface{}, error) {
 	}
 
 	return false, fmt.Errorf("cannot mod %s with %s", reflect.TypeOf(lv).String(), reflect.TypeOf(rv).String())
+}
+
+func isJsonNumber(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	switch v.(type) {
+	case json.Number:
+		return true
+	}
+	return false
 }

--- a/data/expression/script/gocc/ast/comparison.go
+++ b/data/expression/script/gocc/ast/comparison.go
@@ -71,8 +71,15 @@ func (e *cmpEqExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li == ri, nil
 		}
+
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li == ri, nil
+		}
+
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
 			return lf == rf, nil
@@ -150,8 +157,14 @@ func (e *cmpNotEqExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li != ri, nil
 		}
+
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li != ri, nil
+		}
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
 			return lf != rf, nil
@@ -229,8 +242,13 @@ func (e *cmpGtExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li > ri, nil
 		}
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li > ri, nil
+		}
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
 			return lf > rf, nil
@@ -303,8 +321,14 @@ func (e *cmpGtEqExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li >= ri, nil
 		}
+
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li >= ri, nil
+		}
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
 			return lf >= rf, nil
@@ -381,8 +405,13 @@ func (e *cmpLtExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li < ri, nil
 		}
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li < ri, nil
+		}
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
 			return lf < rf, nil
@@ -457,8 +486,13 @@ func (e *cmpLtEqExpr) Eval(scope data.Scope) (interface{}, error) {
 			ri, _ := coerce.ToFloat64(rv)
 			return li <= ri, nil
 		}
+		if isJsonNumber(rv) {
+			li, _ := coerce.ToInt64(lv)
+			ri, _ := coerce.ToInt64(rv)
+			return li <= ri, nil
+		}
 	case float32, float64:
-		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 {
+		if rt == reflect.Int || rt == reflect.Int32 || rt == reflect.Int64 || rt == reflect.Float32 || rt == reflect.Float64 || isJsonNumber(rv) {
 			lf, _ := coerce.ToFloat64(lv)
 			rf, _ := coerce.ToFloat64(rv)
 			return lf <= rf, nil

--- a/data/expression/script/gocc/ast/unary.go
+++ b/data/expression/script/gocc/ast/unary.go
@@ -1,10 +1,12 @@
 package ast
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/project-flogo/core/data"
 	"github.com/project-flogo/core/data/resolve"
 	"reflect"
+	"strings"
 
 	"github.com/project-flogo/core/data/coerce"
 	"github.com/project-flogo/core/data/expression/script/gocc/token"
@@ -79,6 +81,14 @@ func (e *unaryNegExpr) Eval(scope data.Scope) (interface{}, error) {
 	case float32, float64:
 		vf, _ := coerce.ToFloat64(ve)
 		return -vf, nil
+	case json.Number:
+		if strings.Contains(ve.String(), ".") {
+			vf, _ := ve.Float64()
+			return -vf, nil
+		} else {
+			vf, _ := ve.Int64()
+			return -vf, nil
+		}
 	}
 
 	return false, fmt.Errorf("cannot not '%s'", reflect.TypeOf(v).String())


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
The engine has an issue to deal with an expression that has json.number, such as a contribution which return as json.number as output field1

$activity[xxxxx].field1 * 32
$activity[xxxxx].field1 / 32

We will have issue because we never take json.Number as the number at the engine

**What is the new behavior?**

Fixed above an issue that json.Number can be used in the expression.