### PR TITLE
Unmarshalling Go object from byte array

### DIFF
--- a/data/coerce/compound.go
+++ b/data/coerce/compound.go
@@ -13,6 +13,15 @@ func ToParams(val interface{}) (map[string]string, error) {
 	switch t := val.(type) {
 	case map[string]string:
 		return t, nil
+	case []byte:
+		var m map[string]string
+		if len(t) > 0 {
+			err := json.Unmarshal(t, &m)
+			if err != nil {
+				return nil, fmt.Errorf("unable to coerce %#v to params", val)
+			}
+		}
+		return m, nil
 	case string:
 		m := make(map[string]string)
 		if t != "" {
@@ -109,6 +118,15 @@ func ToObject(val interface{}) (map[string]interface{}, error) {
 			ret[key] = value
 		}
 		return ret, nil
+	case []byte:
+		var m map[string]interface{}
+		if len(t) > 0 {
+			err := json.Unmarshal(t, &m)
+			if err != nil {
+				return nil, fmt.Errorf("unable to coerce %#v to map[string]interface{}", val)
+			}
+		}
+		return m, nil
 	case string:
 		m := make(map[string]interface{})
 		if t != "" {
@@ -143,6 +161,15 @@ func ToArray(val interface{}) ([]interface{}, error) {
 		var a []interface{}
 		for _, v := range t {
 			a = append(a, v)
+		}
+		return a, nil
+	case []byte:
+		a := make([]interface{}, 0)
+		if len(a) > 0 {
+			err := json.Unmarshal(t, &a)
+			if err != nil {
+				a = append(a, t)
+			}
 		}
 		return a, nil
 	case string:

--- a/trigger/handler.go
+++ b/trigger/handler.go
@@ -178,9 +178,7 @@ func (h *handlerImpl) Handle(ctx context.Context, triggerData interface{}) (resu
 	var inputMap map[string]interface{}
 
 	if act.actionInputMapper != nil {
-		inScope := data.NewSimpleScope(triggerValues, nil)
-
-		inputMap, err = act.actionInputMapper.Apply(inScope)
+		inputMap, err = act.actionInputMapper.Apply(scope)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[*] Other... Please describe: Code optimize
```

**Fixes**: #

**What is the current behavior?**
1. Today we unmarshal Go Object from either string to an interface which requires conversion if it is an array of byte
2. Additional scope created which has been created.

**What is the new behavior?**

1. Unmarshal Go object from the byte array
2. Avoiding to create a duplicate scope.