### PR TITLE
Fix #231 to report clearly error message when connection not imported

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -553,6 +553,7 @@ func registerImport(anImport string) error {
 
 	ct := getContribType(ref)
 	if ct == "other" {
+		support.SaveNonContributionAlias(alias, ref)
 		log.RootLogger().Debugf("Added Non-Contribution Import: %s", ref)
 		return nil
 		//return fmt.Errorf("invalid import, contribution '%s' not registered", anImport)

--- a/support/alias.go
+++ b/support/alias.go
@@ -3,6 +3,7 @@ package support
 import "fmt"
 
 var aliases = make(map[string]map[string]string)
+var noContributionAlias = make(map[string]string)
 
 func RegisterAlias(contribType, alias, ref string) error {
 
@@ -41,4 +42,19 @@ func GetAliasRef(contribType, alias string) (string, bool) {
 	}
 
 	return ref, true
+}
+
+func SaveNonContributionAlias(alias, ref string) {
+	noContributionAlias[alias] = ref
+}
+
+func GetNonContributionAlias(alias string) string {
+	if alias == "" {
+		return ""
+	}
+
+	if alias[0] == '#' {
+		alias = alias[1:]
+	}
+	return noContributionAlias[alias]
 }

--- a/support/connection/config.go
+++ b/support/connection/config.go
@@ -98,11 +98,19 @@ func ResolveConfig(config *Config) error {
 
 func resolveRef(config *Config) error {
 	if config.Ref[0] == '#' {
-		var ok bool
-		config.Ref, ok = support.GetAliasRef("connection", config.Ref)
+		ref, ok := support.GetAliasRef("connection", config.Ref)
 		if !ok {
-			return fmt.Errorf("connection '%s' not imported", config.Ref)
+			ref = support.GetNonContributionAlias(config.Ref)
+			if ref == "" {
+				ref = config.Ref
+			}
+			if name, exit := config.Settings["name"]; exit {
+				return fmt.Errorf("connection '%s' with ref '%s' not imported", name, ref)
+			} else {
+				return fmt.Errorf("connection '%s' not imported", ref)
+			}
 		}
+		config.Ref = ref
 	}
 	return nil
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #231 

**What is the current behavior?**
Now it throws below error message when the connection not been imported to the engine
```
 connection ' ' not imported
```
**What is the new behavior?**
We should throw a meaningfully error message. such as:

```
connection 'PulsarConn' with ref 'github.com/project-flogo/messaging-contrib/pulsar/connection' not imported
```