### PR TITLE
Fix #237 to delete data from app data

### DIFF
--- a/app/data.go
+++ b/app/data.go
@@ -44,3 +44,13 @@ func SetValue(name string, value interface{}) error {
 	}
 	return appData.SetValue(name, value)
 }
+
+// DeleteValue remove an app attribute
+func DeleteValue(name string) {
+	if log.RootLogger().TraceEnabled() {
+		log.RootLogger().Tracef("Deleting App Value '%s'", name)
+	}
+	if d, ok := appData.(data.NeedsDelete); ok {
+		d.Delete(name)
+	}
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[*] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #237 

**What is the current behavior?**
Today we exposed api app.GetValue and app.SetValue() to save app-level data, and we already had a appdata activity https://github.com/project-flogo/contrib/blob/master/activity/appdata/activity.go .

But there is no way to delete an attribute from the app data cache. It's better to have the ability to delete data as a global data store.
**What is the new behavior?**
Ability to remove/delete app data.

