### PR TITLE
logger enhancement

### DIFF
--- a/activity/legacy.go
+++ b/activity/legacy.go
@@ -2,8 +2,6 @@ package activity
 
 import (
 	"fmt"
-	"path"
-
 	"github.com/project-flogo/core/support/log"
 )
 
@@ -46,9 +44,7 @@ func LegacyRegister(ref string, activity Activity) error {
 	hasLegacy = true
 	activities[ref] = activity
 	legacyTracker[ref] = empty
-	name := path.Base(ref) //todo should probably get this from the descriptor? or on registration provide a short name
-	activityLoggers[ref] = log.ChildLogger(activityLogger, name)
-
+	activityLoggers[ref] = log.CreateLoggerFromRef(rootLogger, "activity", ref)
 	return nil
 }
 

--- a/activity/registry.go
+++ b/activity/registry.go
@@ -2,8 +2,6 @@ package activity
 
 import (
 	"fmt"
-	"path"
-
 	"github.com/project-flogo/core/support"
 	"github.com/project-flogo/core/support/log"
 )
@@ -14,7 +12,7 @@ var (
 	activityLoggers   = make(map[string]log.Logger)
 )
 
-var activityLogger = log.ChildLogger(log.RootLogger(), "activity")
+var rootLogger = log.RootLogger()
 
 func Register(activity Activity, f ...Factory) error {
 
@@ -29,10 +27,9 @@ func Register(activity Activity, f ...Factory) error {
 	}
 
 	log.RootLogger().Debugf("Registering activity: %s", ref)
-
 	activities[ref] = activity
-	name := path.Base(ref) //todo should we use this or the alias?
-	activityLoggers[ref] = log.ChildLogger(activityLogger, name)
+
+	activityLoggers[ref] = log.CreateLoggerFromRef(rootLogger, "activity", ref)
 
 	if len(f) > 1 {
 		log.RootLogger().Warnf("Only one factory can be associated with activity: %s", ref)

--- a/app/instances.go
+++ b/app/instances.go
@@ -210,7 +210,7 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 				}
 			}
 
-			handler, err := trigger.NewHandler(hConfig, acts, mapperFactory, expressionFactory, runner)
+			handler, err := trigger.NewHandler(hConfig, acts, mapperFactory, expressionFactory, runner, logger)
 			if err != nil {
 				return nil, fmt.Errorf("error creating handler [%s] in trigger [%s]:%s", hConfig.Name, tConfig.Id, err.Error())
 			}

--- a/support/log/logger.go
+++ b/support/log/logger.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -95,6 +96,26 @@ func ChildLoggerWithFields(logger Logger, fields ...Field) Logger {
 	}
 
 	return childLogger
+}
+
+func CreateLoggerFromRef(logger Logger, contributionType, ref string) Logger {
+	ref = strings.TrimSpace(ref)
+	if strings.HasSuffix(ref, "/") {
+		ref = ref[:len(ref)-1]
+	}
+	dirs := strings.Split(ref, "/")
+	if len(dirs) >= 3 {
+		name := dirs[len(dirs)-1]
+		acType := dirs[len(dirs)-2]
+		if acType == "activity" || acType == "trigger" || acType == "connector" {
+			categoryName := dirs[len(dirs)-3]
+			return ChildLogger(rootLogger, categoryName+"."+acType+"."+name)
+		} else {
+			return ChildLogger(rootLogger, acType+"."+contributionType+"."+name)
+		}
+	} else {
+		return ChildLogger(rootLogger, contributionType+"."+filepath.Base(ref))
+	}
 }
 
 func Sync() {

--- a/support/log/logger.go
+++ b/support/log/logger.go
@@ -109,12 +109,12 @@ func CreateLoggerFromRef(logger Logger, contributionType, ref string) Logger {
 		acType := dirs[len(dirs)-2]
 		if acType == "activity" || acType == "trigger" || acType == "connector" {
 			categoryName := dirs[len(dirs)-3]
-			return ChildLogger(rootLogger, categoryName+"."+acType+"."+name)
+			return ChildLogger(rootLogger, strings.ToLower(categoryName+"."+acType+"."+name))
 		} else {
-			return ChildLogger(rootLogger, acType+"."+contributionType+"."+name)
+			return ChildLogger(rootLogger, strings.ToLower(acType+"."+contributionType+"."+name))
 		}
 	} else {
-		return ChildLogger(rootLogger, contributionType+"."+filepath.Base(ref))
+		return ChildLogger(rootLogger, strings.ToLower(contributionType+"."+filepath.Base(ref)))
 	}
 }
 

--- a/support/log/logger.go
+++ b/support/log/logger.go
@@ -109,12 +109,12 @@ func CreateLoggerFromRef(logger Logger, contributionType, ref string) Logger {
 		acType := dirs[len(dirs)-2]
 		if acType == "activity" || acType == "trigger" || acType == "connector" {
 			categoryName := dirs[len(dirs)-3]
-			return ChildLogger(rootLogger, strings.ToLower(categoryName+"."+acType+"."+name))
+			return ChildLogger(logger, strings.ToLower(categoryName+"."+acType+"."+name))
 		} else {
-			return ChildLogger(rootLogger, strings.ToLower(acType+"."+contributionType+"."+name))
+			return ChildLogger(logger, strings.ToLower(acType+"."+contributionType+"."+name))
 		}
 	} else {
-		return ChildLogger(rootLogger, strings.ToLower(contributionType+"."+filepath.Base(ref)))
+		return ChildLogger(logger, strings.ToLower(contributionType+"."+filepath.Base(ref)))
 	}
 }
 

--- a/support/test/trigger.go
+++ b/support/test/trigger.go
@@ -49,7 +49,7 @@ func InitTrigger(factory trigger.Factory, tConfig *trigger.Config, actions map[s
 
 		acts = append(acts, act)
 
-		handler, _ := trigger.NewHandler(hConfig, acts, mf, ef, r)
+		handler, _ := trigger.NewHandler(hConfig, acts, mf, ef, r, logger)
 
 		initCtx.handlers = append(initCtx.handlers, handler)
 

--- a/trigger/deprecated.go
+++ b/trigger/deprecated.go
@@ -24,6 +24,7 @@ func LegacyRegister(ref string, f Factory) error {
 	}
 
 	log.RootLogger().Debugf("Registering legacy trigger [ %s ]", ref)
+	triggerLoggers[ref] = log.CreateLoggerFromRef(rootLogger, "trigger", ref)
 
 	triggerFactories[ref] = f
 

--- a/trigger/handler.go
+++ b/trigger/handler.go
@@ -19,6 +19,7 @@ var handlerLog = log.ChildLogger(log.RootLogger(), "handler")
 
 type Handler interface {
 	Name() string
+	Logger() log.Logger
 	Settings() map[string]interface{}
 	Schemas() *SchemaConfig
 	Handle(ctx context.Context, triggerData interface{}) (map[string]interface{}, error)
@@ -33,6 +34,7 @@ type actImpl struct {
 
 type handlerImpl struct {
 	runner    action.Runner
+	logger    log.Logger
 	config    *HandlerConfig
 	acts      []actImpl
 	eventData map[string]string
@@ -50,17 +52,21 @@ func (h *handlerImpl) Settings() map[string]interface{} {
 	return h.config.Settings
 }
 
+func (h *handlerImpl) Logger() log.Logger {
+	return h.logger
+}
+
 func (h *handlerImpl) SetDefaultEventData(data map[string]string) {
 	h.eventData = data
 }
 
-func NewHandler(config *HandlerConfig, acts []action.Action, mf mapper.Factory, ef expression.Factory, runner action.Runner) (Handler, error) {
+func NewHandler(config *HandlerConfig, acts []action.Action, mf mapper.Factory, ef expression.Factory, runner action.Runner, logger log.Logger) (Handler, error) {
 
 	if len(acts) == 0 {
 		return nil, errors.New("no action specified for handler")
 	}
 
-	handler := &handlerImpl{config: config, acts: make([]actImpl, len(acts)), runner: runner}
+	handler := &handlerImpl{config: config, acts: make([]actImpl, len(acts)), runner: runner, logger: log.ChildLogger(logger, config.Name)}
 
 	var err error
 

--- a/trigger/handler_test.go
+++ b/trigger/handler_test.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"context"
+	"github.com/project-flogo/core/support/log"
 	"testing"
 
 	"github.com/project-flogo/core/action"
@@ -43,17 +44,17 @@ func TestNewHandler(t *testing.T) {
 	expf := expression.NewFactory(defResolver)
 
 	//Action not specified
-	handler, err := NewHandler(hCfg, nil, mf, expf, runner.NewDirect())
+	handler, err := NewHandler(hCfg, nil, mf, expf, runner.NewDirect(), log.RootLogger())
 	assert.NotNil(t, err, "Actions not specified.")
 
 	//Parent not defined in the Handler Config
-	handler, err = NewHandler(hCfg, []action.Action{&MockAction{}}, mf, expf, runner.NewDirect())
+	handler, err = NewHandler(hCfg, []action.Action{&MockAction{}}, mf, expf, runner.NewDirect(), log.RootLogger())
 	_, err = handler.Handle(context.Background(), map[string]interface{}{"anInput": "input"})
 	assert.NotNil(t, err, "Parent not defined.")
 
 	//Parent defined.
 	hCfg.parent = &Config{Id: "sampleTrig"}
-	handler, err = NewHandler(hCfg, []action.Action{&MockAction{}}, mf, expf, runner.NewDirect())
+	handler, err = NewHandler(hCfg, []action.Action{&MockAction{}}, mf, expf, runner.NewDirect(), log.RootLogger())
 	assert.Nil(t, err)
 	assert.NotNil(t, handler)
 

--- a/trigger/registry.go
+++ b/trigger/registry.go
@@ -2,10 +2,8 @@ package trigger
 
 import (
 	"fmt"
-	"github.com/project-flogo/core/support/log"
-	"path"
-
 	"github.com/project-flogo/core/support"
+	"github.com/project-flogo/core/support/log"
 )
 
 var (
@@ -13,7 +11,7 @@ var (
 	triggerLoggers   = make(map[string]log.Logger)
 )
 
-var triggerLogger = log.ChildLogger(log.RootLogger(), "trigger")
+var rootLogger = log.RootLogger()
 
 func Register(trigger Trigger, f Factory) error {
 
@@ -35,9 +33,7 @@ func Register(trigger Trigger, f Factory) error {
 
 	triggerFactories[ref] = f
 
-	triggerName := path.Base(ref) //todo get this from the descriptor or register trigger with name as well
-	triggerLoggers[ref] = log.ChildLogger(triggerLogger, triggerName)
-
+	triggerLoggers[ref] = log.CreateLoggerFromRef(rootLogger, "trigger", ref)
 	return nil
 }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #
The PR has 2 fixes
1. Changer logger name to have the category name.  such as `flogo.contrib.activity.log` `flogo.pulsar.activity. publish`, same for trigger
2.  Create a child handler logger from the trigger.  1 trigger has multiple handlers so it makes sense to have the handler's own logger.
**What is the current behavior?**
1.  Today we just take `flogo.activity.ActivityTypeName` as logger name which will have an issue if one flow has many query activity which comes from different contribution which will have difficult to know which `query` print the log.
2. No handler specific log. all logs using the trigger's log.  

**What is the new behavior?**
1. Adding category name as part of logger name which makes thing more clear
2. Adding handler specific logger