### PR TITLE
Add handler name and trigger id as context of handler logger

### DIFF
--- a/app/instances.go
+++ b/app/instances.go
@@ -117,7 +117,6 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 			logger = log.ChildLoggerWithFields(logger, log.FieldString("triggerId", tConfig.Id))
 		}
 
-		log.ChildLogger(logger, tConfig.Id)
 		initCtx := &initContext{logger: logger, handlers: make([]trigger.Handler, 0, len(tConfig.Handlers))}
 
 		//create handlers for that trigger and init

--- a/trigger/handler.go
+++ b/trigger/handler.go
@@ -66,8 +66,18 @@ func NewHandler(config *HandlerConfig, acts []action.Action, mf mapper.Factory, 
 		return nil, errors.New("no action specified for handler")
 	}
 
-	handler := &handlerImpl{config: config, acts: make([]actImpl, len(acts)), runner: runner, logger: log.ChildLogger(logger, config.Name)}
+	var handlerLogger log.Logger
+	if log.CtxLoggingEnabled() {
+		if config.parent != nil {
+			handlerLogger = log.ChildLoggerWithFields(logger, log.FieldString("handlerName", config.Name), log.FieldString("triggerId", config.parent.Id))
+		} else {
+			handlerLogger = log.ChildLoggerWithFields(logger, log.FieldString("handlerName", config.Name))
+		}
+	} else {
+		handlerLogger = log.ChildLogger(logger, "handler")
+	}
 
+	handler := &handlerImpl{config: config, acts: make([]actImpl, len(acts)), runner: runner, logger: handlerLogger}
 	var err error
 
 	//todo we could filter inputs/outputs based on the metadata, maybe make this an option


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[*] Other... Please describe: Enhance the handler logger
```

**Fixes**: #

**What is the current behavior?**

Today we added handler name as part of logger name which causes trigger name too long if user have a long name for the handler. 
**What is the new behavior?**

Move handler name to context logger which only prints when enabling context logging.