### PR TITLE
We should handle []byte to array rather just return byte array

### DIFF
--- a/data/coerce/compound.go
+++ b/data/coerce/compound.go
@@ -165,7 +165,7 @@ func ToArray(val interface{}) ([]interface{}, error) {
 		return a, nil
 	case []byte:
 		a := make([]interface{}, 0)
-		if len(a) > 0 {
+		if len(t) > 0 {
 			err := json.Unmarshal(t, &a)
 			if err != nil {
 				a = append(a, t)

--- a/data/coerce/compound.go
+++ b/data/coerce/compound.go
@@ -210,8 +210,17 @@ func ToArrayIfNecessary(val interface{}) (interface{}, error) {
 		return nil, nil
 	}
 
-	rt := reflect.TypeOf(val).Kind()
+	//Try to handle []byte
+	switch t := val.(type) {
+	case []byte:
+		a := make([]interface{}, 0)
+		err := json.Unmarshal(t, &a)
+		if err == nil {
+			return a, nil
+		}
+	}
 
+	rt := reflect.TypeOf(val).Kind()
 	if rt == reflect.Array || rt == reflect.Slice {
 		return val, nil
 	}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
When trying to convert []bytes to an array using Totype which just returns []byte but we expected to return go object array.
**What is the new behavior?**
Convert byte array to Go object array.