### PR TITLE
Print error stack trance only on debug mode

### DIFF
--- a/support/log/logger.go
+++ b/support/log/logger.go
@@ -3,7 +3,6 @@ package log
 import (
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 )
 
@@ -21,9 +20,6 @@ const (
 
 	EnvKeyLogSeparator  = "FLOGO_LOG_SEPARATOR"
 	DefaultLogSeparator = "\t"
-
-	EnvPrintStackTraceOnError     = "FLOGO_LOG_STACKTRACE_ON_ERROR"
-	DefaultPrintStackTraceOnError = true
 
 	TraceLevel Level = iota
 	DebugLevel
@@ -162,7 +158,7 @@ func configureLogging() {
 		logFormat = FormatJson
 	}
 
-	rootLogger = newZapRootLogger("flogo", logFormat)
+	rootLogger = newZapRootLogger("flogo", logFormat, rootLogLevel)
 	SetLogLevel(rootLogger, rootLogLevel)
 }
 
@@ -194,13 +190,4 @@ func getLogSeparator() string {
 		return v
 	}
 	return DefaultLogSeparator
-}
-
-func printStackTraceOnError() bool {
-	v, ok := os.LookupEnv(EnvPrintStackTraceOnError)
-	if ok && len(v) > 0 {
-		y, _ := strconv.ParseBool(v)
-		return y
-	}
-	return false
 }

--- a/support/log/logger.go
+++ b/support/log/logger.go
@@ -3,6 +3,7 @@ package log
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -20,6 +21,9 @@ const (
 
 	EnvKeyLogSeparator  = "FLOGO_LOG_SEPARATOR"
 	DefaultLogSeparator = "\t"
+
+	EnvPrintStackTraceOnError     = "FLOGO_LOG_STACKTRACE_ON_ERROR"
+	DefaultPrintStackTraceOnError = true
 
 	TraceLevel Level = iota
 	DebugLevel
@@ -190,4 +194,13 @@ func getLogSeparator() string {
 		return v
 	}
 	return DefaultLogSeparator
+}
+
+func printStackTraceOnError() bool {
+	v, ok := os.LookupEnv(EnvPrintStackTraceOnError)
+	if ok && len(v) > 0 {
+		y, _ := strconv.ParseBool(v)
+		return y
+	}
+	return false
 }

--- a/support/log/zap.go
+++ b/support/log/zap.go
@@ -161,7 +161,6 @@ func newZapLogger(logFormat Format) (*zap.Logger, *zap.AtomicLevel, error) {
 	eCfg := cfg.EncoderConfig
 	eCfg.TimeKey = "timestamp"
 	eCfg.EncodeTime = zapcore.ISO8601TimeEncoder
-	//eCfg.EncodeTime = zapcore.EpochNanosTimeEncoder
 
 	if logFormat == FormatConsole {
 		eCfg.EncodeLevel = zapcore.CapitalLevelEncoder
@@ -170,6 +169,11 @@ func newZapLogger(logFormat Format) (*zap.Logger, *zap.AtomicLevel, error) {
 	}
 
 	eCfg.ConsoleSeparator = getLogSeparator()
+	//Don't print stacktrace for error logs
+	if !printStackTraceOnError() {
+		eCfg.StacktraceKey = ""
+	}
+
 	cfg.EncoderConfig = eCfg
 
 	lvl := cfg.Level

--- a/support/log/zap.go
+++ b/support/log/zap.go
@@ -135,9 +135,9 @@ func toZapLogLevel(level Level) zapcore.Level {
 	return zapcore.InfoLevel
 }
 
-func newZapRootLogger(name string, format Format) Logger {
+func newZapRootLogger(name string, format Format, level Level) Logger {
 
-	zl, lvl, _ := newZapLogger(format)
+	zl, lvl, _ := newZapLogger(format, level)
 
 	var rootLogger Logger
 	if name == "" {
@@ -154,7 +154,7 @@ func newZapRootLogger(name string, format Format) Logger {
 	return rootLogger
 }
 
-func newZapLogger(logFormat Format) (*zap.Logger, *zap.AtomicLevel, error) {
+func newZapLogger(logFormat Format, level Level) (*zap.Logger, *zap.AtomicLevel, error) {
 	cfg := zap.NewProductionConfig()
 	cfg.DisableCaller = true
 
@@ -169,8 +169,8 @@ func newZapLogger(logFormat Format) (*zap.Logger, *zap.AtomicLevel, error) {
 	}
 
 	eCfg.ConsoleSeparator = getLogSeparator()
-	//Don't print stacktrace for error logs
-	if !printStackTraceOnError() {
+	//Don't print stacktrace for log level lower than debug
+	if level > DebugLevel {
 		eCfg.StacktraceKey = ""
 	}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #251 

**What is the current behavior?**

Today we print error stack trace at INFO or ERROR LEVEL which prints too many logs.  The stack trace should be print when only for Log Level at DEBUG or wider level.
```
021-03-25T10:01:46.491-0500    DEBUG   [flogo.contrib.activity.error] -        Applying InputMapper
2021-03-25T10:01:46.491-0500    DEBUG   [flogo.contrib.activity.error] -        Message :'dadsasdasdasdasd', Data: '<nil>'
2021-03-25T10:01:46.492-0500    INFO    [flogo.contrib.activity.error] -        Eval activity [ThrowError] on instance [c8f38217419f43e6f4c92b2e3d755458] done, took: 44.92µs
2021-03-25T10:01:46.492-0500    ERROR   [flogo.contrib.activity.error] -        Execution failed for Activity[ThrowError] in Flow[asdasd] - dadsasdasdasdasd
github.com/project-flogo/flow/instance.(*TaskInst).EvalActivity.func1
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/taskinst.go:302
github.com/project-flogo/flow/instance.(*TaskInst).EvalActivity
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/taskinst.go:357
github.com/project-flogo/flow/model/simple.evalActivity
        /Users/xli/gopath/src/github.com/project-flogo/flow/model/simple/taskbehavior.go:116
github.com/project-flogo/flow/model/simple.(*TaskBehavior).Eval
        /Users/xli/gopath/src/github.com/project-flogo/flow/model/simple/taskbehavior.go:95
github.com/project-flogo/flow/instance.(*IndependentInstance).execTask
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/ind_instance.go:277
github.com/project-flogo/flow/instance.(*IndependentInstance).DoStep
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/ind_instance.go:219
github.com/project-flogo/flow.(*FlowAction).Run.func1
        /Users/xli/gopath/src/github.com/project-flogo/flow/action.go:330
2021-03-25T10:01:46.492-0500    ERROR   [flogo.flow] -  Error evaluating activity 'ThrowError'[github.com/project-flogo/contrib/activity/error] - dadsasdasdasdasd
github.com/project-flogo/flow/model/simple.(*TaskBehavior).Eval
        /Users/xli/gopath/src/github.com/project-flogo/flow/model/simple/taskbehavior.go:99
github.com/project-flogo/flow/instance.(*IndependentInstance).execTask
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/ind_instance.go:277
github.com/project-flogo/flow/instance.(*IndependentInstance).DoStep
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/ind_instance.go:219
github.com/project-flogo/flow.(*FlowAction).Run.func1
        /Users/xli/gopath/src/github.com/project-flogo/flow/action.go:330
2021-03-25T10:01:46.492-0500    DEBUG   [flogo.flow] -  SetAttr - name: _E, value:map[activity:ThrowError code: data:<nil> message:dadsasdasdasdasd type:activity]

2021-03-25T10:01:46.492-0500    DEBUG   [flogo.flow] -  SetAttr - name: _E.ThrowError, value:map[activity:ThrowError code: data:<nil> message:dadsasdasdasdasd type:activity]

2021-03-25T10:01:46.492-0500    ERROR   [flogo.flow] -  dadsasdasdasdasd
github.com/project-flogo/flow/instance.(*IndependentInstance).HandleGlobalError
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/ind_instance.go:535
github.com/project-flogo/flow/instance.(*IndependentInstance).handleTaskError
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/ind_instance.go:498
github.com/project-flogo/flow/instance.(*IndependentInstance).execTask
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/ind_instance.go:282
github.com/project-flogo/flow/instance.(*IndependentInstance).DoStep
        /Users/xli/gopath/src/github.com/project-flogo/flow/instance/ind_instance.go:219
github.com/project-flogo/flow.(*FlowAction).Run.func1
        /Users/xli/gopath/src/github.com/project-flogo/flow/action.go:330

```

**What is the new behavior?**

Only Print stacktrace at DEBUG or Trace level.  

```
2021-03-25T10:22:24.892-0500    INFO    [flogo.general.activity.log] -  www===============
2021-03-25T10:22:24.892-0500    INFO    [flogo.general.activity.log] -  Eval activity [LogMessage] on instance [7bc7c5c3e2731676e1bc86d5a1ad37b0] done, took: 22.625µs
2021-03-25T10:22:24.892-0500    INFO    [flogo.contrib.activity.error] -        Eval activity [ThrowError] on instance [7bc7c5c3e2731676e1bc86d5a1ad37b0] done, took: 2.782µs
2021-03-25T10:22:24.892-0500    ERROR   [flogo.contrib.activity.error] -        Execution failed for Activity[ThrowError] in Flow[asdasd] - dadsasdasdasdasd
2021-03-25T10:22:24.893-0500    ERROR   [flogo.flow] -  Error evaluating activity 'ThrowError'[github.com/project-flogo/contrib/activity/error] - dadsasdasdasdasd
2021-03-25T10:22:24.893-0500    ERROR   [flogo.flow] -  dadsasdasdasdasd
2021-03-25T10:22:24.893-0500    INFO    [flogo.flow] -  Instance [7bc7c5c3e2731676e1bc86d5a1ad37b0] with event id [f9eeae74255a92ff4bc9cb6d4549291a] Failed, took:2.002988491s

```
