### PR TITLE
Give unique id(eventid) for each handler request to tight with action instance

### DIFF
--- a/trigger/context.go
+++ b/trigger/context.go
@@ -2,26 +2,60 @@ package trigger
 
 import (
 	"context"
+	"github.com/project-flogo/core/support"
+	"time"
 )
 
-type key int
+var handlerKey = "_ctx_handler_info"
 
-var handlerKey key
+var idGenerator, _ = support.NewGenerator()
 
 type HandlerInfo struct {
-	Name string
+	Name      string
+	EventId   string
+	StartTime time.Time
 }
 
 // NewHandlerContext add the handler info to a new child context
 func NewHandlerContext(parentCtx context.Context, config *HandlerConfig) context.Context {
-	if config != nil && config.Name != "" {
-		return context.WithValue(parentCtx, handlerKey, &HandlerInfo{Name: config.Name})
+	return NewHandlerContextWithEventId(parentCtx, config, idGenerator.NextAsString())
+}
+
+// NewHandlerContextWithEventId add the handler info to a new child context with event id and starting time
+func NewHandlerContextWithEventId(parentCtx context.Context, config *HandlerConfig, eventId string) context.Context {
+	value := parentCtx.Value(handlerKey)
+	if value != nil {
+		info, ok := value.(*HandlerInfo)
+		if ok {
+			if len(info.EventId) > 0 {
+				return parentCtx
+			} else {
+				info.EventId = eventId
+				info.StartTime = time.Now()
+			}
+		}
 	}
-	return parentCtx
+	return context.WithValue(parentCtx, handlerKey, &HandlerInfo{Name: config.Name, EventId: eventId, StartTime: time.Now()})
 }
 
 // HandlerFromContext returns the handler info stored in the context, if any.
 func HandlerFromContext(ctx context.Context) (*HandlerInfo, bool) {
 	u, ok := ctx.Value(handlerKey).(*HandlerInfo)
 	return u, ok
+}
+
+func GetHandlerEventIdFromContext(ctx context.Context) string {
+	u, ok := ctx.Value(handlerKey).(*HandlerInfo)
+	if ok {
+		return u.EventId
+	}
+	return ""
+}
+
+func GetHandleStartTimeFromContext(ctx context.Context) time.Time {
+	u, ok := ctx.Value(handlerKey).(*HandlerInfo)
+	if ok {
+		return u.StartTime
+	}
+	return time.Time{}
 }

--- a/trigger/context.go
+++ b/trigger/context.go
@@ -8,7 +8,15 @@ import (
 
 var handlerKey = "_ctx_handler_info"
 
-var idGenerator, _ = support.NewGenerator()
+var idGenerator *support.Generator
+
+func init() {
+	var err error
+	idGenerator, err = support.NewGenerator()
+	if err != nil {
+		panic("initialization uuid generator error:" + err.Error())
+	}
+}
 
 type HandlerInfo struct {
 	Name      string


### PR DESCRIPTION

**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[*] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #252 

**What is the current behavior?**
* Today there is no way that we can track requests from triggers always down to action instances in logs.  such as Trigger -> Handler -> Action -> Done.  It is super difficult to debugging from logs or find a way that can associate one request from handler to flow instance.  
* No handler execution time took been printed at logs
**What is the new behavior?**

* I came up with a way that each request from the hander will associate with a unique key(Event Id with UUID), the key will be pass to action instance through context.  From the action side, they can get the key from context and use it for logging for tracking purposes. 
* The Event Id should able to be overridden by trigger developer where they can give their business logic perspective id.  such as Message-ID etc.
* Print time took by handle each handler. 

Example logs:

![image](https://user-images.githubusercontent.com/987686/112500624-8c91c780-8d56-11eb-82b4-73bee32ad169.png)
