### PR TITLE
Adding extra index field when do array mapping assign

### DIFF
--- a/data/mapper/object.go
+++ b/data/mapper/object.go
@@ -515,13 +515,18 @@ func newLoopScope(arrayItem interface{}, scopeName string, index int, scope data
 		mapData[primitiveArrayData] = arrayItem
 	}
 
-	mapData[foreach_Index] = index
-	loopData := make(map[string]interface{})
-	loopData["_loop"] = mapData
-	if len(scopeName) > 0 {
-		loopData[scopeName] = mapData
+	//Avoid impact source data, copy one here for mapping
+	arrayElementMap := make(map[string]interface{}, len(mapData))
+	for k, v := range mapData {
+		arrayElementMap[k] = v
 	}
 
+	arrayElementMap[foreach_Index] = index
+	loopData := make(map[string]interface{})
+	loopData["_loop"] = arrayElementMap
+	if len(scopeName) > 0 {
+		loopData[scopeName] = arrayElementMap
+	}
 	return data.NewSimpleScope(loopData, scope), nil
 }
 

--- a/data/mapper/object_test.go
+++ b/data/mapper/object_test.go
@@ -1182,6 +1182,8 @@ func TestArrayMappingWithFilterAndUpdate(t *testing.T) {
 	assert.Equal(t, float64(592), arr.(map[string]interface{})["books"].([]interface{})[0].(map[string]interface{})["pageCount"])
 	assert.Equal(t, "1003", arr.(map[string]interface{})["books"].([]interface{})[0].(map[string]interface{})["isbn"])
 	assert.Equal(t, "Testing", arr.(map[string]interface{})["books"].([]interface{})[0].(map[string]interface{})["status"])
+	assert.Nil(t, arr.(map[string]interface{})["books"].([]interface{})[0].(map[string]interface{})["index"])
+
 }
 
 func TestLiteralAssign(t *testing.T) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**

When do array mapping with assign, such as mapping 

```
 "@foreach($.books, index, $loop.title == \"IOS\")":{
			"=":"$loop"
}
```
With source array 
```
 {
    "title": "IOS",
    "isbn": "1935182722",
    "pageCount": 592,
    "publishedDate": { "$date": "2011-01-14T00:00:00.000-0800" },
    "status": "PUBLISH",
    "authors": ["W. Frank Ableson", "Robi Sen"],
    "categories": ["Java"]
  }
```
extra `index` array elements have been added to the result. 

```
 {
    "index":0,
    "title": "IOS",
    "isbn": "1935182722",
    "pageCount": 592,
    "publishedDate": { "$date": "2011-01-14T00:00:00.000-0800" },
    "status": "PUBLISH",
    "authors": ["W. Frank Ableson", "Robi Sen"],
    "categories": ["Java"]
  }
```

**What is the new behavior?**

We should avoid adding `index` field in the JSON.
