### PR TITLE
maintain trigger startup order especially for lifecycle triggers

### DIFF
--- a/app/controller.go
+++ b/app/controller.go
@@ -68,9 +68,9 @@ func (c *controllerData) ReleaseControl() error {
 func (app *App) initFlowController() {
 	controllerData := &controllerData{lock: sync.Mutex{}}
 	controllerData.triggers = make(map[string]trigger.FlowControlAware)
-	for id, trgW := range app.triggers {
+	for _, trgW := range app.triggers {
 		if t, ok := trgW.trg.(trigger.FlowControlAware); ok {
-			controllerData.triggers[id] = t
+			controllerData.triggers[trgW.id] = t
 		}
 	}
 	controller = controllerData

--- a/app/instances.go
+++ b/app/instances.go
@@ -58,18 +58,19 @@ func (a *App) createSharedActions(actionConfigs []*action.Config) (map[string]ac
 	return actions, nil
 }
 
-func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (map[string]*triggerWrapper, error) {
+func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) ([]*triggerWrapper, error) {
 
-	triggers := make(map[string]*triggerWrapper)
+	triggers := make([]*triggerWrapper, len(tConfigs))
 
 	mapperFactory := mapper.NewFactory(a.resolver)
 	expressionFactory := expression.NewFactory(a.resolver)
 
-	for _, tConfig := range tConfigs {
+	for i, tConfig := range tConfigs {
 
-		_, exists := triggers[tConfig.Id]
-		if exists {
-			return nil, fmt.Errorf("trigger with id '%s' already registered, trigger ids have to be unique", tConfig.Id)
+		for _, t := range triggers {
+			if t != nil && t.id == tConfig.Id {
+				return nil, fmt.Errorf("trigger with id '%s' already registered, trigger ids have to be unique", tConfig.Id)
+			}
 		}
 
 		if tConfig.Ref == "" && tConfig.Type != "" {
@@ -224,7 +225,7 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 		}
 		trigger.PostTriggerEvent(trigger.INITIALIZED, tConfig.Id)
 
-		triggers[tConfig.Id] = &triggerWrapper{ref: ref, trg: trg, status: &managed.StatusInfo{Name: tConfig.Id}}
+		triggers[i] = &triggerWrapper{id: tConfig.Id, ref: ref, trg: trg, status: &managed.StatusInfo{Name: tConfig.Id}}
 	}
 
 	return triggers, nil


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[*] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
When we have multiple OnStartup Triggers be added in one app. the order of those triggers is not guaranteed.  Sometime it is random because we are using the map to store them in Go, The map in go doesn't maintain order. 
**What is the new behavior?**

Convert Map to array to make sure the order is matter
