### PR TITLE
Trace context enhancements

### DIFF
--- a/support/trace/context.go
+++ b/support/trace/context.go
@@ -1,11 +1,14 @@
 package trace
 
-import "context"
+import (
+	"context"
+
+	"github.com/project-flogo/core/support/log"
+)
 
 type key struct{}
 
 var id = key{}
-
 
 type TracingContext interface {
 	// TraceObject() returns underlying tracing implementation
@@ -16,11 +19,16 @@ type TracingContext interface {
 	SetTag(tagKey string, tagValue interface{}) bool
 	// LogKV() allows you to log additional details about the entity being traced
 	LogKV(kvs map[string]interface{}) bool
+	// TraceID() returns trace ID
+	TraceID() string
+	// SpanID() returns span ID
+	SpanID() string
 }
 
 type Config struct {
 	Operation string
 	Tags      map[string]interface{}
+	Logger    log.Logger
 }
 
 func AppendTracingContext(goCtx context.Context, tracingContext TracingContext) context.Context {

--- a/support/trace/context_test.go
+++ b/support/trace/context_test.go
@@ -2,12 +2,20 @@ package trace
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type TestTracingContext struct {
+}
 
+func (t TestTracingContext) TraceID() string {
+	return ""
+}
+
+func (t TestTracingContext) SpanID() string {
+	return ""
 }
 
 func (t TestTracingContext) TraceObject() interface{} {
@@ -31,16 +39,16 @@ func TestAppendTracingContext(t *testing.T) {
 	tCtx := &TestTracingContext{}
 
 	goCtx := AppendTracingContext(context.Background(), tCtx)
- 	tc, ok := goCtx.Value(id).(TracingContext)
+	tc, ok := goCtx.Value(id).(TracingContext)
 
- 	assert.True(t, ok)
- 	assert.Equal(t, tCtx, tc)
+	assert.True(t, ok)
+	assert.Equal(t, tCtx, tc)
 }
 
 func TestExtractTracingContext(t *testing.T) {
 
 	tCtx := &TestTracingContext{}
-	goCtx := context.WithValue(nil, id, tCtx)
+	goCtx := context.WithValue(context.Background(), id, tCtx)
 
 	ttCtx := ExtractTracingContext(goCtx)
 	assert.Equal(t, tCtx, ttCtx)


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[X] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently trace and span Id not exposed through trace context also tracers can not log contextual details since activity/flow logger is not available.
**What is the new behavior?**
With this change,  core runtime can easily fetch and expose trace ID/ space ID. Also, tracers can use activity/flow logger to log tracing context like traceId/spanId etc in the implementation.