### PR TITLE
FLOGO_APP_DELAYED_STOP_INTERVAL is max wait time for engine shutdown …

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,12 +2,6 @@ package app
 
 import (
 	"fmt"
-	"path"
-	"regexp"
-	"runtime/debug"
-	"strings"
-	"time"
-
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/activity"
 	appresolve "github.com/project-flogo/core/app/resolve"
@@ -24,6 +18,10 @@ import (
 	"github.com/project-flogo/core/support/managed"
 	"github.com/project-flogo/core/support/service"
 	"github.com/project-flogo/core/trigger"
+	"path"
+	"regexp"
+	"runtime/debug"
+	"strings"
 )
 
 type Option func(*App) error
@@ -480,7 +478,7 @@ func (a *App) Stop() error {
 		logger.Info("Triggers Stopped")
 	}
 
-	delayedStopInterval := GetDelayedStopInterval()
+	/* delayedStopInterval := GetDelayedStopInterval()
 	if delayedStopInterval != "" {
 		// Delay stopping of connection manager so that in-flight actions can continue until specified interval
 		// No new events will be processed as triggers are stopped.
@@ -491,7 +489,7 @@ func (a *App) Stop() error {
 			logger.Infof("Delaying application stop by - %s", delayedStopInterval)
 			time.Sleep(duration)
 		}
-	}
+	}  */
 
 	// Start managed actions
 	hasManagedActions := false

--- a/engine/runner/direct.go
+++ b/engine/runner/direct.go
@@ -25,7 +25,8 @@ func (runner *DirectRunner) Start() error {
 
 // Stop will stop the engine, by stopping all of its workers
 func (runner *DirectRunner) Stop() error {
-	//no-op
+	// check if all actions done till waiting time
+	gracefulStop()
 	return nil
 }
 
@@ -35,7 +36,8 @@ func (runner *DirectRunner) RunAction(ctx context.Context, act action.Action, in
 	if act == nil {
 		return nil, errors.New("action not specified")
 	}
-
+	trackActions.Add(1)
+	defer trackActions.Done()
 	if syncAct, ok := act.(action.SyncAction); ok {
 		return syncAct.Run(ctx, inputs)
 	} else if asyncAct, ok := act.(action.AsyncAction); ok {

--- a/engine/runner/worker.go
+++ b/engine/runner/worker.go
@@ -74,6 +74,7 @@ func (w ActionWorker) Start() {
 	logger := log.RootLogger()
 
 	go func() {
+		defer trackActions.Done()
 		for {
 			// Add ourselves into the worker queue.
 			w.WorkerQueue <- w.Work


### PR DESCRIPTION
…if any inflight actions running

**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?** While graceful engine shutdown , it waits for FLOGO_APP_DELAYED_STOP_INTERVAL configured duration irrespective whether inflight actions present or not. This results into redundant delay while app repush and scale-in as engine waits for 10sec (in TCI) even when no running actions present or actions completed in lesser duration.
Usecase:  let say running actions completed in 2 sec but engine still **waits for 10 sec** for graceful shutdown.
 
**What is the new behavior?** While graceful engine shutdown , Engine will only wait for **max** FLOGO_APP_DELAYED_STOP_INTERVAL duration if there any inflight actions running. Engine will shutdown as soon as all running actions completed. 
Usecase:  let say pending actions completed in 2 sec then engine will shutdown after 2 sec and **will no wait for 10 sec** as a part of graceful shutdown.