### PR TITLE
Engine will gracefully shutdown even before FLOGO_APP_DELAYED_STOP_IN…

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,12 +2,6 @@ package app
 
 import (
 	"fmt"
-	"path"
-	"regexp"
-	"runtime/debug"
-	"strings"
-	"time"
-
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/activity"
 	appresolve "github.com/project-flogo/core/app/resolve"
@@ -24,6 +18,10 @@ import (
 	"github.com/project-flogo/core/support/managed"
 	"github.com/project-flogo/core/support/service"
 	"github.com/project-flogo/core/trigger"
+	"path"
+	"regexp"
+	"runtime/debug"
+	"strings"
 )
 
 type Option func(*App) error
@@ -480,7 +478,7 @@ func (a *App) Stop() error {
 		logger.Info("Triggers Stopped")
 	}
 
-	delayedStopInterval := GetDelayedStopInterval()
+	/* delayedStopInterval := GetDelayedStopInterval()
 	if delayedStopInterval != "" {
 		// Delay stopping of connection manager so that in-flight actions can continue until specified interval
 		// No new events will be processed as triggers are stopped.
@@ -491,7 +489,7 @@ func (a *App) Stop() error {
 			logger.Infof("Delaying application stop by - %s", delayedStopInterval)
 			time.Sleep(duration)
 		}
-	}
+	}  */
 
 	// Start managed actions
 	hasManagedActions := false

--- a/engine/runner/direct.go
+++ b/engine/runner/direct.go
@@ -37,8 +37,8 @@ func (runner *DirectRunner) RunAction(ctx context.Context, act action.Action, in
 	if act == nil {
 		return nil, errors.New("action not specified")
 	}
-	trackDirectRunnerActions.AddTracker()
-	defer trackDirectRunnerActions.DoneTracker()
+	trackDirectRunnerActions.AddRunner()
+	defer trackDirectRunnerActions.RemoveRunner()
 	if syncAct, ok := act.(action.SyncAction); ok {
 		return syncAct.Run(ctx, inputs)
 	} else if asyncAct, ok := act.(action.AsyncAction); ok {

--- a/engine/runner/pooled.go
+++ b/engine/runner/pooled.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"errors"
-
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/support"
 	"github.com/project-flogo/core/support/log"
@@ -43,6 +42,8 @@ func NewPooled(config *PooledConfig) *PooledRunner {
 	return &pooledRunner
 }
 
+var trackPooledRunnerActions = NewRunnerTracker() //RunnerTracker{runnertrackerwg: &sync.WaitGroup{}}
+
 // Start will start the engine, by starting all of its workers
 func (runner *PooledRunner) Start() error {
 
@@ -59,6 +60,7 @@ func (runner *PooledRunner) Start() error {
 			logger.Debugf("Starting worker with id '%d'", id)
 			worker := NewWorker(id, runner.directRunner, runner.workerQueue)
 			runner.workers[i] = &worker
+			trackPooledRunnerActions.AddTracker()
 			worker.Start()
 		}
 
@@ -96,6 +98,8 @@ func (runner *PooledRunner) Stop() error {
 			runner.logger.Debug("Stopping worker", worker.ID)
 			worker.Stop()
 		}
+		// check if all actions done till shutdown waiting time
+		trackPooledRunnerActions.gracefulStop()
 	}
 
 	return nil

--- a/engine/runner/pooled.go
+++ b/engine/runner/pooled.go
@@ -60,7 +60,7 @@ func (runner *PooledRunner) Start() error {
 			logger.Debugf("Starting worker with id '%d'", id)
 			worker := NewWorker(id, runner.directRunner, runner.workerQueue)
 			runner.workers[i] = &worker
-			trackPooledRunnerActions.AddTracker()
+			trackPooledRunnerActions.AddRunner()
 			worker.Start()
 		}
 

--- a/engine/runner/runner_tracker.go
+++ b/engine/runner/runner_tracker.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"github.com/project-flogo/core/app"
+	"github.com/project-flogo/core/support/log"
+	"sync"
+	"time"
+)
+
+func NewRunnerTracker() *RunnerTracker {
+	return &RunnerTracker{runnertrackerwg: &sync.WaitGroup{}}
+}
+
+type RunnerTracker struct {
+	runnertrackerwg *sync.WaitGroup
+}
+
+func (rt RunnerTracker) AddTracker() {
+	rt.runnertrackerwg.Add(1)
+}
+
+func (rt RunnerTracker) DoneTracker() {
+	rt.runnertrackerwg.Done()
+}
+
+func (rt RunnerTracker) WaitForTrackerAllDone() {
+	rt.runnertrackerwg.Wait()
+}
+
+func (rt RunnerTracker) WaitForActionsCompletion(timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		rt.WaitForTrackerAllDone()
+	}()
+	select {
+	case <-c:
+		return false // actions completed
+	case <-time.After(timeout):
+		return true // timed out
+	}
+}
+
+func (rt RunnerTracker) gracefulStop() {
+	logger := log.RootLogger()
+	delayedStopInterval := app.GetDelayedStopInterval()
+	if delayedStopInterval != "" {
+		duration, err := time.ParseDuration(delayedStopInterval)
+		if err != nil {
+			logger.Errorf("Invalid interval - %s  specified for delayed stop. It must suffix with time unit e.g. %sms, %ss", delayedStopInterval, delayedStopInterval, delayedStopInterval)
+		} else {
+			logger.Infof("Delaying application stop by max - %s", delayedStopInterval)
+			if isTimeout := rt.WaitForActionsCompletion(duration); isTimeout {
+				logger.Info("All actions not completed before engine shutdown")
+			} else {
+				logger.Info("All actions completed before engine shutdown")
+			}
+		}
+
+	}
+}

--- a/engine/runner/runner_tracker.go
+++ b/engine/runner/runner_tracker.go
@@ -15,23 +15,23 @@ type RunnerTracker struct {
 	runnertrackerwg *sync.WaitGroup
 }
 
-func (rt RunnerTracker) AddTracker() {
+func (rt RunnerTracker) AddRunner() {
 	rt.runnertrackerwg.Add(1)
 }
 
-func (rt RunnerTracker) DoneTracker() {
+func (rt RunnerTracker) RemoveRunner() {
 	rt.runnertrackerwg.Done()
 }
 
-func (rt RunnerTracker) WaitForTrackerAllDone() {
+func (rt RunnerTracker) WaitForAllRunners() {
 	rt.runnertrackerwg.Wait()
 }
 
-func (rt RunnerTracker) WaitForActionsCompletion(timeout time.Duration) bool {
+func (rt RunnerTracker) WaitForRunnersCompletion(timeout time.Duration) bool {
 	c := make(chan struct{})
 	go func() {
 		defer close(c)
-		rt.WaitForTrackerAllDone()
+		rt.WaitForAllRunners()
 	}()
 	select {
 	case <-c:
@@ -50,7 +50,7 @@ func (rt RunnerTracker) gracefulStop() {
 			logger.Errorf("Invalid interval - %s  specified for delayed stop. It must suffix with time unit e.g. %sms, %ss", delayedStopInterval, delayedStopInterval, delayedStopInterval)
 		} else {
 			logger.Infof("Delaying application stop by max - %s", delayedStopInterval)
-			if isTimeout := rt.WaitForActionsCompletion(duration); isTimeout {
+			if isTimeout := rt.WaitForRunnersCompletion(duration); isTimeout {
 				logger.Info("All actions not completed before engine shutdown")
 			} else {
 				logger.Info("All actions completed before engine shutdown")

--- a/engine/runner/worker.go
+++ b/engine/runner/worker.go
@@ -74,7 +74,7 @@ func (w ActionWorker) Start() {
 	logger := log.RootLogger()
 
 	go func() {
-		defer trackPooledRunnerActions.DoneTracker()
+		defer trackPooledRunnerActions.RemoveRunner()
 		for {
 			// Add ourselves into the worker queue.
 			w.WorkerQueue <- w.Work

--- a/engine/runner/worker.go
+++ b/engine/runner/worker.go
@@ -74,6 +74,7 @@ func (w ActionWorker) Start() {
 	logger := log.RootLogger()
 
 	go func() {
+		defer trackPooledRunnerActions.DoneTracker()
 		for {
 			// Add ourselves into the worker queue.
 			w.WorkerQueue <- w.Work


### PR DESCRIPTION
…TERVAL if all running actions completed

**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
While graceful engine shutdown , it waits for FLOGO_APP_DELAYED_STOP_INTERVAL configured duration irrespective whether inflight actions present or not. This results into redundant delay while app repush and scale-in as engine waits for 10sec (in TCI) even when no running actions present or actions completed in lesser duration.
Usecase: let say running actions completed in 2 sec but engine still waits for 10 sec for graceful shutdown.

**What is the new behavior?**
While graceful engine shutdown , Engine will only wait for max FLOGO_APP_DELAYED_STOP_INTERVAL duration if there any inflight actions running. Engine will shutdown as soon as all running actions completed.
Usecase: let say pending actions completed in 2 sec then engine will shutdown after 2 sec and will not wait for 10 sec as a part of graceful shutdown.