### PR TITLE
Dynamic reconfiguration support

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -39,3 +39,7 @@ type Details struct {
 type HasDetails interface {
 	Details() *Details
 }
+
+type ReconfigurableActivity interface {
+	Reconfigure(settings map[string]interface{}) error
+}

--- a/app/app.go
+++ b/app/app.go
@@ -577,30 +577,22 @@ func (a *App) Reconfigure() error {
 	logger.Info("App properties are successfully reconfigured")
 
 	// Reconfigure connections
-	for id, config := range appConfig.Connections {
-		err = connection.Reconfigure(id, config)
-		if err != nil {
-			log.RootLogger().Errorf("Failed to reconfigure connection: %s due to error: %v", id, err)
-			return err
-		}
+	err = connection.ReconfigureConnections(appConfig.Connections)
+	if err != nil {
+		return err
 	}
 
-	// Load flows
-	for _, resConfig := range appConfig.Resources {
-		err = a.resManager.Reconfigure(resConfig)
-		if err != nil {
-			log.RootLogger().Errorf("Failed to reconfigure resource: %s due to error: %v", resConfig.ID, err)
-			return err
-		}
+	// Reconfigure resources e.g. flows
+	err = a.resManager.ReconfigureResources(appConfig.Resources)
+	if err != nil {
+		return err
 	}
-	logger.Info("App resources are successfully reconfigured")
 
 	// Reconfigure triggers
 	err = a.reconfigureTriggers(appConfig.Triggers, a.actionRunner)
 	if err != nil {
 		return err
 	}
-
 	logger.Info("App successfully reconfigured")
 	return nil
 }

--- a/app/app.go
+++ b/app/app.go
@@ -656,7 +656,7 @@ func (a *App) Reconfigure() error {
 				if err != nil {
 					return err
 				}
-				err = reconfigManager.Reconfigure(config.Settings)
+				err = reconfigManager.ReconfigureConnection(config.Settings)
 				if err != nil {
 					return err
 				}

--- a/app/app.go
+++ b/app/app.go
@@ -559,9 +559,14 @@ func (a *App) Reconfigure() error {
 	if !AutoReconfigurationEnabled() {
 		return fmt.Errorf("App is not configured for auto reconfiguration. Set %s=true to enable this feature", EnvKeyAutoReconfigure)
 	}
-	var appConfig Config
+
 	var err error
-	err = json.Unmarshal(a.config, &appConfig)
+	appConfig := &struct {
+		Triggers    []*trigger.Config             `json:"triggers"`
+		Resources   []*resource.Config            `json:"resources,omitempty"`
+		Connections map[string]*connection.Config `json:"connections,omitempty"`
+	}{}
+	err = json.Unmarshal(a.config, appConfig)
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path"
 	"regexp"
 	"runtime/debug"
@@ -74,8 +73,6 @@ func New(config *Config, runner action.Runner, options ...Option) (*App, error) 
 		app.config, _ = json.Marshal(config)
 		app.options = options
 		app.actionRunner = runner
-		// Enable property snapshot feature to ensure inflight instance use same app properties value during execution
-		_ = os.Setenv(property.EnvAppPropertySnapshotEnabled, "true")
 	}
 
 	properties := make(map[string]interface{}, len(config.Properties))
@@ -267,10 +264,11 @@ type App struct {
 }
 
 type triggerWrapper struct {
-	id     string
-	ref    string
-	trg    trigger.Trigger
-	status *managed.StatusInfo
+	id       string
+	ref      string
+	trg      trigger.Trigger
+	status   *managed.StatusInfo
+	handlers []trigger.Handler
 }
 
 func (a *App) GetProperty(name string) (interface{}, bool) {

--- a/app/app.go
+++ b/app/app.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strings"
-	"time"
 
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/activity"
@@ -75,6 +74,8 @@ func New(config *Config, runner action.Runner, options ...Option) (*App, error) 
 		app.config, _ = json.Marshal(config)
 		app.options = options
 		app.actionRunner = runner
+		// Enable property snapshot feature to ensure inflight instance use same app properties value during execution
+		_ = os.Setenv(property.EnvAppPropertySnapshotEnabled, "true")
 	}
 
 	properties := make(map[string]interface{}, len(config.Properties))
@@ -547,7 +548,6 @@ func (a *App) Stop() error {
 
 	logger.Debugf("Cleaning up resources")
 	a.resManager.CleanupResources()
-
 	return nil
 }
 
@@ -567,48 +567,6 @@ func (a *App) Reconfigure() error {
 	if err != nil {
 		return err
 	}
-
-	// Stop current normal triggers
-	// OnShutdown triggers are excluded from restart
-	if len(a.triggers) > 0 {
-		var triggers []*triggerWrapper
-		for _, trgW := range a.triggers {
-			if _, ok := trgW.trg.(LifecycleAware); !ok && !skippedTrigger(trgW.id) {
-				triggers = append(triggers, trgW)
-			}
-		}
-
-		if len(triggers) > 0 {
-			logger.Info("Stopping Triggers...")
-			for _, trg := range triggers {
-				_ = managed.Stop("Trigger [ "+trg.id+" ]", trg.trg)
-				trg.status.Status = managed.StatusStopped
-				trigger.PostTriggerEvent(trigger.STOPPED, trg.id)
-			}
-			logger.Info("Triggers Stopped")
-		}
-	}
-
-	delayedStopInterval := GetDelayedStopInterval()
-	if delayedStopInterval != "" {
-		// Delay stopping of app so that in-flight actions can continue until specified interval
-		// No new events will be processed as triggers are stopped.
-		duration, err := time.ParseDuration(delayedStopInterval)
-		if err != nil {
-			logger.Errorf("Invalid interval - %s  specified for delayed stop. It must suffix with time unit e.g. %sms, %ss", delayedStopInterval, delayedStopInterval, delayedStopInterval)
-		} else {
-			logger.Infof("Delaying application stop by - %s", delayedStopInterval)
-			time.Sleep(duration)
-		}
-	}
-
-	logger.Debugf("Cleaning up singleton activities")
-	activity.CleanupSingletons()
-
-	logger.Debugf("Cleaning up resources")
-	a.resManager.CleanupResources()
-
-	a.started = false
 	// Reload app configuration
 	for _, option := range a.options {
 		err = option(a)
@@ -616,92 +574,36 @@ func (a *App) Reconfigure() error {
 			return err
 		}
 	}
+	logger.Info("App properties are successfully reconfigured")
 
 	// Reconfigure connections
 	for id, config := range appConfig.Connections {
-		err = connection.ReconfigureManager(id, config)
+		err = connection.Reconfigure(id, config)
 		if err != nil {
+			log.RootLogger().Errorf("Failed to reconfigure connection: %s due to error: %v", id, err)
 			return err
 		}
 	}
 
 	// Load flows
 	for _, resConfig := range appConfig.Resources {
-		resType, err := resource.GetTypeFromID(resConfig.ID)
+		err = a.resManager.Reconfigure(resConfig)
 		if err != nil {
+			log.RootLogger().Errorf("Failed to reconfigure resource: %s due to error: %v", resConfig.ID, err)
 			return err
 		}
-
-		loader := resource.GetLoader(resType)
-		if loader == nil {
-			return fmt.Errorf("resource loader for '%s' not registered", resType)
-		}
-		res, err := loader.LoadResource(resConfig)
-		if err != nil {
-			return err
-		}
-		// Update resource
-		a.resManager.SetResource(resConfig.ID, res)
 	}
+	logger.Info("App resources are successfully reconfigured")
 
 	// Reconfigure triggers
-	var triggerConfig []*trigger.Config
-	for _, tc := range appConfig.Triggers {
-		if !skippedTrigger(tc.Id) {
-			triggerConfig = append(triggerConfig, tc)
-		}
+	err = a.reconfigureTriggers(appConfig.Triggers, a.actionRunner)
+	if err != nil {
+		return err
 	}
-	if len(triggerConfig) > 0 {
-		err = a.reconfigureTriggers(triggerConfig, a.actionRunner)
-		if err != nil {
-			return err
-		}
-	}
+	logger.Info("App triggers are successfully reconfigured")
 
-	// Start normal triggers
-	// OnStartup triggers are excluded from restart
-	if len(a.triggers) > 0 {
-		var normalTriggers []*triggerWrapper
-		for _, trgW := range a.triggers {
-			if _, ok := trgW.trg.(LifecycleAware); !ok && !skippedTrigger(trgW.id) {
-				normalTriggers = append(normalTriggers, trgW)
-			}
-		}
-
-		if len(normalTriggers) > 0 {
-			logger.Info("Starting Triggers...")
-			var failed []string
-			for _, trg := range normalTriggers {
-				ok, err := a.startTrigger(trg)
-				if err != nil {
-					return err
-				}
-				if !ok {
-					failed = append(failed, trg.id)
-				}
-			}
-
-			if len(failed) > 0 {
-				//remove failed trigger, we have no use for them
-				for _, triggerId := range failed {
-					for index, tr := range a.triggers {
-						if triggerId == tr.id {
-							//Delete it
-							a.triggers = append(a.triggers[:index], a.triggers[index+1:]...)
-						}
-					}
-				}
-			}
-			logger.Info("Triggers Started")
-		}
-	}
-	a.started = true
 	logger.Info("App successfully reconfigured")
 	return nil
-}
-
-func skippedTrigger(id string) bool {
-	return strings.Contains(os.Getenv(EnvKeyAutoReconfigureSkipTriggers), id)
 }
 
 func registerImport(anImport string) error {

--- a/app/app.go
+++ b/app/app.go
@@ -553,6 +553,7 @@ func (a *App) Stop() error {
 
 // Reconfigure function restarts the app
 func (a *App) Reconfigure() error {
+	logger := log.RootLogger()
 	if !a.started {
 		return fmt.Errorf("app is not started")
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -600,7 +600,6 @@ func (a *App) Reconfigure() error {
 	if err != nil {
 		return err
 	}
-	logger.Info("App triggers are successfully reconfigured")
 
 	logger.Info("App successfully reconfigured")
 	return nil

--- a/app/app.go
+++ b/app/app.go
@@ -629,6 +629,9 @@ func (a *App) Reconfigure() error {
 	logger.Debugf("Cleaning up singleton activities")
 	activity.CleanupSingletons()
 
+	logger.Debugf("Cleaning up resources")
+	a.resManager.CleanupResources()
+
 	a.started = false
 	// Reload app configuration
 	for _, option := range a.options {

--- a/app/app.go
+++ b/app/app.go
@@ -683,10 +683,18 @@ func (a *App) Reconfigure() error {
 		a.resManager.SetResource(resConfig.ID, res)
 	}
 
-	// Load trigger configuration
-	a.triggers, err = a.createTriggers(appConfig.Triggers, a.actionRunner)
-	if err != nil {
-		return err
+	// Reconfigure triggers
+	var triggerConfig []*trigger.Config
+	for _, tc := range appConfig.Triggers {
+		if !skippedTrigger(tc.Id) {
+			triggerConfig = append(triggerConfig, tc)
+		}
+	}
+	if len(triggerConfig) > 0 {
+		err = a.reconfigureTriggers(triggerConfig, a.actionRunner)
+		if err != nil {
+			return err
+		}
 	}
 
 	managers = connection.Managers()

--- a/app/config.go
+++ b/app/config.go
@@ -13,8 +13,10 @@ import (
 )
 
 const (
-	EnvKeyDelayedAppStopInterval = "FLOGO_APP_DELAYED_STOP_INTERVAL"
-	EnvKeyEnableFlowControl      = "FLOGO_APP_ENABLE_FLOW_CONTROL"
+	EnvKeyDelayedAppStopInterval      = "FLOGO_APP_DELAYED_STOP_INTERVAL"
+	EnvKeyEnableFlowControl           = "FLOGO_APP_ENABLE_FLOW_CONTROL"
+	EnvKeyOnDemandRestart             = "FLOGO_APP_ONDEMAND_RESTART"
+	EnvKeyOnDemandRestartSkipTriggers = "FLOGO_APP_RESTART_SKIP_TRIGGERS"
 )
 
 // Def is the configuration for the App
@@ -41,6 +43,15 @@ func GetDelayedStopInterval() string {
 		return intervalEnv
 	}
 	return ""
+}
+
+func AppOnDemandRestartEnabled() bool {
+	reconfigureApp := os.Getenv(EnvKeyOnDemandRestart)
+	if len(reconfigureApp) <= 0 {
+		return false
+	}
+	b, _ := strconv.ParseBool(reconfigureApp)
+	return b
 }
 
 func EnableFlowControl() bool {

--- a/app/config.go
+++ b/app/config.go
@@ -13,10 +13,9 @@ import (
 )
 
 const (
-	EnvKeyDelayedAppStopInterval      = "FLOGO_APP_DELAYED_STOP_INTERVAL"
-	EnvKeyEnableFlowControl           = "FLOGO_APP_ENABLE_FLOW_CONTROL"
-	EnvKeyAutoReconfigure             = "FLOGO_APP_AUTO_RECONFIGURE"
-	EnvKeyAutoReconfigureSkipTriggers = "FLOGO_APP_RECONFIGURE_SKIP_TRIGGERS"
+	EnvKeyDelayedAppStopInterval = "FLOGO_APP_DELAYED_STOP_INTERVAL"
+	EnvKeyEnableFlowControl      = "FLOGO_APP_ENABLE_FLOW_CONTROL"
+	EnvKeyAutoReconfigure        = "FLOGO_APP_AUTO_RECONFIGURE"
 )
 
 // Config is the configuration for the App

--- a/app/config.go
+++ b/app/config.go
@@ -15,11 +15,11 @@ import (
 const (
 	EnvKeyDelayedAppStopInterval      = "FLOGO_APP_DELAYED_STOP_INTERVAL"
 	EnvKeyEnableFlowControl           = "FLOGO_APP_ENABLE_FLOW_CONTROL"
-	EnvKeyOnDemandRestart             = "FLOGO_APP_ONDEMAND_RESTART"
-	EnvKeyOnDemandRestartSkipTriggers = "FLOGO_APP_RESTART_SKIP_TRIGGERS"
+	EnvKeyAutoReconfigure             = "FLOGO_APP_AUTO_RECONFIGURE"
+	EnvKeyAutoReconfigureSkipTriggers = "FLOGO_APP_RECONFIGURE_SKIP_TRIGGERS"
 )
 
-// Def is the configuration for the App
+// Config is the configuration for the App
 type Config struct {
 	Name        string `json:"name"`
 	Type        string `json:"type"`
@@ -45,8 +45,8 @@ func GetDelayedStopInterval() string {
 	return ""
 }
 
-func AppOnDemandRestartEnabled() bool {
-	reconfigureApp := os.Getenv(EnvKeyOnDemandRestart)
+func AutoReconfigurationEnabled() bool {
+	reconfigureApp := os.Getenv(EnvKeyAutoReconfigure)
 	if len(reconfigureApp) <= 0 {
 		return false
 	}

--- a/app/controller.go
+++ b/app/controller.go
@@ -67,10 +67,10 @@ func (c *controllerData) ReleaseControl() error {
 	return nil
 }
 
-func (app *App) initEventFlowController() {
+func (a *App) initEventFlowController() {
 	controllerData := &controllerData{lock: sync.Mutex{}}
 	controllerData.triggers = make(map[string]trigger.Trigger)
-	for _, trgW := range app.triggers {
+	for _, trgW := range a.triggers {
 		controllerData.triggers[trgW.id] = trgW.trg
 	}
 	controller = controllerData

--- a/app/instances.go
+++ b/app/instances.go
@@ -351,23 +351,10 @@ type initContext struct {
 	logger   log.Logger
 }
 
-type reconfigurableContext struct {
-	handlers      []trigger.Handler
-	triggerConfig *trigger.Config
-}
-
 func (ctx *initContext) GetHandlers() []trigger.Handler {
 	return ctx.handlers
 }
 
 func (ctx *initContext) Logger() log.Logger {
 	return ctx.logger
-}
-
-func (ctx *reconfigurableContext) Handlers() []trigger.Handler {
-	return ctx.handlers
-}
-
-func (ctx *reconfigurableContext) Config() *trigger.Config {
-	return ctx.triggerConfig
 }

--- a/app/instances.go
+++ b/app/instances.go
@@ -279,10 +279,10 @@ func (a *App) reconfigureTriggers(tConfigs []*trigger.Config, runner action.Runn
 		tLogger := trigger.GetLogger(ref)
 
 		if log.CtxLoggingEnabled() {
-			logger = log.ChildLoggerWithFields(tLogger, log.FieldString("triggerId", tConfig.Id))
+			tLogger = log.ChildLoggerWithFields(tLogger, log.FieldString("triggerId", tConfig.Id))
 		}
 
-		initCtx := &initContext{logger: logger, handlers: make([]trigger.Handler, 0, len(tConfig.Handlers))}
+		initCtx := &initContext{logger: tLogger, handlers: make([]trigger.Handler, 0, len(tConfig.Handlers))}
 
 		//create handlers for that trigger and init
 		for _, hConfig := range tConfig.Handlers {

--- a/app/instances.go
+++ b/app/instances.go
@@ -168,7 +168,7 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 							return nil, fmt.Errorf("action factory '%s' referenced by trigger [%s]'s handler [%s], has not been registered\"", ref, tConfig.Id, hConfig.Name)
 						}
 
-						act, err := actionFactory.New(act.Config)
+						nAct, err := actionFactory.New(act.Config)
 						if err != nil {
 							return nil, fmt.Errorf("error creating action [%s] for trigger [%s]'s handler [%s]\"", ref, tConfig.Id, hConfig.Name)
 						}
@@ -176,7 +176,7 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 						//	a.toDispose = append(a.toDispose, needsDisposal)
 						//}
 
-						acts = append(acts, act)
+						acts = append(acts, nAct)
 					}
 				}
 			}
@@ -230,165 +230,117 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 
 	return triggers, nil
 }
+
 func (a *App) reconfigureTriggers(tConfigs []*trigger.Config, runner action.Runner) error {
 
 	mapperFactory := mapper.NewFactory(a.resolver)
 	expressionFactory := expression.NewFactory(a.resolver)
 
 	for _, tConfig := range tConfigs {
-
-		if tConfig.Ref == "" && tConfig.Type != "" {
-			log.RootLogger().Warnf("trigger [%s]'s configuration uses deprecated property 'type', use 'ref' in the future", tConfig.Id)
-			tConfig.Ref = "#" + tConfig.Type
-		}
-
-		ref := tConfig.Ref
-
-		if tConfig.Ref == "" {
-			return fmt.Errorf("trigger [%s]'s ref not specified", tConfig.Id)
-		}
-
-		if tConfig.Ref[0] == '#' {
-			var ok bool
-			ref, ok = support.GetAliasRef("trigger", tConfig.Ref)
-			if !ok {
-				return fmt.Errorf("unable to start trigger [%s], ref alias '%s' has no corresponding installed trigger", tConfig.Id, tConfig.Ref)
-			}
-		}
-
-		triggerFactory := trigger.GetFactory(ref)
-
-		if triggerFactory == nil {
-			return fmt.Errorf("trigger [%s]'s factory '%s' not registered", tConfig.Id, ref)
-		}
-
-		err := tConfig.FixUp(triggerFactory.Metadata(), a.resolver)
-		if err != nil {
-			return fmt.Errorf("error fixing up trigger [%s]'s metadata:%s", tConfig.Id, err.Error())
-		}
-
-		trg, err := triggerFactory.New(tConfig)
-		if err != nil {
-			return fmt.Errorf("error creating trigger [%s]:%s", tConfig.Id, err.Error())
-		}
-
-		if trg == nil {
-			return fmt.Errorf("cannot create trigger [%s] with nil", tConfig.Id)
-		}
-
-		tLogger := trigger.GetLogger(ref)
-
-		if log.CtxLoggingEnabled() {
-			tLogger = log.ChildLoggerWithFields(tLogger, log.FieldString("triggerId", tConfig.Id))
-		}
-
-		initCtx := &initContext{logger: tLogger, handlers: make([]trigger.Handler, 0, len(tConfig.Handlers))}
-
-		//create handlers for that trigger and init
-		for _, hConfig := range tConfig.Handlers {
-
-			var acts []action.Action
-			var err error
-
-			if len(hConfig.Actions) == 0 {
-				return fmt.Errorf("trigger '%s' has a handler with no action", tConfig.Id)
-			}
-
-			//use action if already associated with Handler
-			for _, act := range hConfig.Actions {
-				if act.Act != nil {
-					acts = append(acts, act.Act)
-				} else {
-					if id := act.Id; id != "" {
-						act, _ := a.actions[id]
-						if act == nil {
-							return fmt.Errorf("trigger [%s]'s handler [%s] references nonexistent shared action '%s'", tConfig.Id, hConfig.Name, id)
-						}
-						acts = append(acts, act)
-					} else {
-						//create the action
-						if act.Ref == "" && act.Type != "" {
-							log.RootLogger().Warnf("action configuration 'type' deprecated in trigger [%s]'s handler [%s], use 'ref' in the future", tConfig.Id, hConfig.Name)
-							act.Ref = "#" + act.Type
-						}
-
-						if act.Ref == "" {
-							return fmt.Errorf("ref not specified for action in trigger [%s]'s handler [%s]", tConfig.Id, hConfig.Name)
-						}
-
-						ref := act.Ref
-						if act.Ref[0] == '#' {
-							var ok bool
-							ref, ok = support.GetAliasRef("action", act.Ref)
-							if !ok {
-								return fmt.Errorf("action '%s' referenced in trigger [%s]'s handler [%s], has not been imported", act.Ref, tConfig.Id, hConfig.Name)
-							}
-						}
-
-						actionFactory := action.GetFactory(ref)
-						if actionFactory == nil {
-							return fmt.Errorf("action factory '%s' referenced by trigger [%s]'s handler [%s], has not been registered\"", ref, tConfig.Id, hConfig.Name)
-						}
-
-						act, err := actionFactory.New(act.Config)
-						if err != nil {
-							return fmt.Errorf("error creating action [%s] for trigger [%s]'s handler [%s]\"", ref, tConfig.Id, hConfig.Name)
-						}
-
-						acts = append(acts, act)
-					}
+		tw := a.getTrigger(tConfig.Id)
+		if tw != nil {
+			reconfigurableTrigger, ok := tw.trg.(trigger.ReconfigurableTrigger)
+			if ok {
+				if tConfig.Ref == "" && tConfig.Type != "" {
+					log.RootLogger().Warnf("trigger [%s]'s configuration uses deprecated property 'type', use 'ref' in the future", tConfig.Id)
+					tConfig.Ref = "#" + tConfig.Type
 				}
-			}
 
-			// Resolve schema references
-			if hConfig.Schemas != nil {
-				if out := hConfig.Schemas.Output; out != nil {
-					for name, def := range out {
-						ref, ok := def.(string)
-						if ok {
-							s, err := schema.FindOrCreate(ref)
+				ref := tConfig.Ref
+				if tConfig.Ref[0] == '#' {
+					ref, _ = support.GetAliasRef("trigger", tConfig.Ref)
+				}
+
+				triggerFactory := trigger.GetFactory(ref)
+				err := tConfig.FixUp(triggerFactory.Metadata(), a.resolver)
+				if err != nil {
+					return fmt.Errorf("error fixing up trigger [%s]'s metadata:%s", tConfig.Id, err.Error())
+				}
+
+				handlers := make([]trigger.Handler, 0, len(tConfig.Handlers))
+				//create new handlers for the trigger as old handlers still might be in use
+				for _, hConfig := range tConfig.Handlers {
+					var acts []action.Action
+					var err error
+
+					for _, act := range hConfig.Actions {
+						if id := act.Id; id != "" {
+							act, _ := a.actions[id]
+							if act == nil {
+								return fmt.Errorf("trigger [%s]'s handler [%s] references nonexistent shared action '%s'", tConfig.Id, hConfig.Name, id)
+							}
+							acts = append(acts, act)
+						} else {
+							//create the action
+							if act.Ref == "" && act.Type != "" {
+								log.RootLogger().Warnf("action configuration 'type' deprecated in trigger [%s]'s handler [%s], use 'ref' in the future", tConfig.Id, hConfig.Name)
+								act.Ref = "#" + act.Type
+							}
+
+							ref = act.Ref
+							if act.Ref[0] == '#' {
+								ref, _ = support.GetAliasRef("action", act.Ref)
+							}
+							actionFactory := action.GetFactory(ref)
+							nAction, err := actionFactory.New(act.Config)
 							if err != nil {
-								return fmt.Errorf("unable to find or create output schema [%s] for trigger [%s]'s handler [%s]: %s", ref, tConfig.Id, hConfig.Name, err.Error())
+								return fmt.Errorf("error creating action [%s] for trigger [%s]'s handler [%s]\"", ref, tConfig.Id, hConfig.Name)
 							}
-							hConfig.Schemas.Output[name] = s
+							acts = append(acts, nAction)
 						}
 					}
-				}
 
-				if reply := hConfig.Schemas.Reply; reply != nil {
-					for name, def := range reply {
-						ref, ok := def.(string)
-						if ok {
-							s, err := schema.FindOrCreate(ref)
-							if err != nil {
-								return fmt.Errorf("unable to find or create reply schema [%s] in trigger [%s]'s handler [%s]: %s", ref, tConfig.Id, hConfig.Name, err.Error())
+					// Resolve schema references
+					if hConfig.Schemas != nil {
+						if out := hConfig.Schemas.Output; out != nil {
+							for name, def := range out {
+								ref, ok := def.(string)
+								if ok {
+									s, err := schema.FindOrCreate(ref)
+									if err != nil {
+										return fmt.Errorf("unable to find or create output schema [%s] for trigger [%s]'s handler [%s]: %s", ref, tConfig.Id, hConfig.Name, err.Error())
+									}
+									hConfig.Schemas.Output[name] = s
+								}
 							}
-							hConfig.Schemas.Reply[name] = s
+						}
+
+						if reply := hConfig.Schemas.Reply; reply != nil {
+							for name, def := range reply {
+								ref, ok := def.(string)
+								if ok {
+									s, err := schema.FindOrCreate(ref)
+									if err != nil {
+										return fmt.Errorf("unable to find or create reply schema [%s] in trigger [%s]'s handler [%s]: %s", ref, tConfig.Id, hConfig.Name, err.Error())
+									}
+									hConfig.Schemas.Reply[name] = s
+								}
+							}
 						}
 					}
+					handler, err := trigger.NewHandler(hConfig, acts, mapperFactory, expressionFactory, runner, logger)
+					if err != nil {
+						return fmt.Errorf("error creating handler [%s] in trigger [%s]:%s", hConfig.Name, tConfig.Id, err.Error())
+					}
+					handlers = append(handlers, handler)
 				}
-			}
 
-			handler, err := trigger.NewHandler(hConfig, acts, mapperFactory, expressionFactory, runner, logger)
-			if err != nil {
-				return fmt.Errorf("error creating handler [%s] in trigger [%s]:%s", hConfig.Name, tConfig.Id, err.Error())
+				err = reconfigurableTrigger.Reconfigure(tConfig, handlers)
+				if err != nil {
+					log.RootLogger().Errorf("Failed to reconfigure trigger: %s due to error: %v", tConfig.Id, err)
+					return nil
+				}
+				log.RootLogger().Infof("Trigger: %s successfully reconfigured", tConfig.Id)
 			}
+		}
+	}
+	return nil
+}
 
-			initCtx.handlers = append(initCtx.handlers, handler)
-		}
-		trigger.PostTriggerEvent(trigger.INITIALIZING, tConfig.Id)
-		err = trg.Initialize(initCtx)
-		if err != nil {
-			trigger.PostTriggerEvent(trigger.INIT_FAILED, tConfig.Id)
-			return fmt.Errorf("error initializing trigger [%s]:%s", tConfig.Id, err.Error())
-		}
-		trigger.PostTriggerEvent(trigger.INITIALIZED, tConfig.Id)
-		for _, t := range a.triggers {
-			if t.id == tConfig.Id {
-				// Update trigger instance
-				t.trg = trg
-				break
-			}
+func (a *App) getTrigger(id string) *triggerWrapper {
+	for _, t := range a.triggers {
+		if t.id == id {
+			return t
 		}
 	}
 	return nil
@@ -399,10 +351,23 @@ type initContext struct {
 	logger   log.Logger
 }
 
+type reconfigurableContext struct {
+	handlers      []trigger.Handler
+	triggerConfig *trigger.Config
+}
+
 func (ctx *initContext) GetHandlers() []trigger.Handler {
 	return ctx.handlers
 }
 
 func (ctx *initContext) Logger() log.Logger {
 	return ctx.logger
+}
+
+func (ctx *reconfigurableContext) Handlers() []trigger.Handler {
+	return ctx.handlers
+}
+
+func (ctx *reconfigurableContext) Config() *trigger.Config {
+	return ctx.triggerConfig
 }

--- a/app/instances.go
+++ b/app/instances.go
@@ -230,6 +230,169 @@ func (a *App) createTriggers(tConfigs []*trigger.Config, runner action.Runner) (
 
 	return triggers, nil
 }
+func (a *App) reconfigureTriggers(tConfigs []*trigger.Config, runner action.Runner) error {
+
+	mapperFactory := mapper.NewFactory(a.resolver)
+	expressionFactory := expression.NewFactory(a.resolver)
+
+	for _, tConfig := range tConfigs {
+
+		if tConfig.Ref == "" && tConfig.Type != "" {
+			log.RootLogger().Warnf("trigger [%s]'s configuration uses deprecated property 'type', use 'ref' in the future", tConfig.Id)
+			tConfig.Ref = "#" + tConfig.Type
+		}
+
+		ref := tConfig.Ref
+
+		if tConfig.Ref == "" {
+			return fmt.Errorf("trigger [%s]'s ref not specified", tConfig.Id)
+		}
+
+		if tConfig.Ref[0] == '#' {
+			var ok bool
+			ref, ok = support.GetAliasRef("trigger", tConfig.Ref)
+			if !ok {
+				return fmt.Errorf("unable to start trigger [%s], ref alias '%s' has no corresponding installed trigger", tConfig.Id, tConfig.Ref)
+			}
+		}
+
+		triggerFactory := trigger.GetFactory(ref)
+
+		if triggerFactory == nil {
+			return fmt.Errorf("trigger [%s]'s factory '%s' not registered", tConfig.Id, ref)
+		}
+
+		err := tConfig.FixUp(triggerFactory.Metadata(), a.resolver)
+		if err != nil {
+			return fmt.Errorf("error fixing up trigger [%s]'s metadata:%s", tConfig.Id, err.Error())
+		}
+
+		trg, err := triggerFactory.New(tConfig)
+		if err != nil {
+			return fmt.Errorf("error creating trigger [%s]:%s", tConfig.Id, err.Error())
+		}
+
+		if trg == nil {
+			return fmt.Errorf("cannot create trigger [%s] with nil", tConfig.Id)
+		}
+
+		tLogger := trigger.GetLogger(ref)
+
+		if log.CtxLoggingEnabled() {
+			logger = log.ChildLoggerWithFields(tLogger, log.FieldString("triggerId", tConfig.Id))
+		}
+
+		initCtx := &initContext{logger: logger, handlers: make([]trigger.Handler, 0, len(tConfig.Handlers))}
+
+		//create handlers for that trigger and init
+		for _, hConfig := range tConfig.Handlers {
+
+			var acts []action.Action
+			var err error
+
+			if len(hConfig.Actions) == 0 {
+				return fmt.Errorf("trigger '%s' has a handler with no action", tConfig.Id)
+			}
+
+			//use action if already associated with Handler
+			for _, act := range hConfig.Actions {
+				if act.Act != nil {
+					acts = append(acts, act.Act)
+				} else {
+					if id := act.Id; id != "" {
+						act, _ := a.actions[id]
+						if act == nil {
+							return fmt.Errorf("trigger [%s]'s handler [%s] references nonexistent shared action '%s'", tConfig.Id, hConfig.Name, id)
+						}
+						acts = append(acts, act)
+					} else {
+						//create the action
+						if act.Ref == "" && act.Type != "" {
+							log.RootLogger().Warnf("action configuration 'type' deprecated in trigger [%s]'s handler [%s], use 'ref' in the future", tConfig.Id, hConfig.Name)
+							act.Ref = "#" + act.Type
+						}
+
+						if act.Ref == "" {
+							return fmt.Errorf("ref not specified for action in trigger [%s]'s handler [%s]", tConfig.Id, hConfig.Name)
+						}
+
+						ref := act.Ref
+						if act.Ref[0] == '#' {
+							var ok bool
+							ref, ok = support.GetAliasRef("action", act.Ref)
+							if !ok {
+								return fmt.Errorf("action '%s' referenced in trigger [%s]'s handler [%s], has not been imported", act.Ref, tConfig.Id, hConfig.Name)
+							}
+						}
+
+						actionFactory := action.GetFactory(ref)
+						if actionFactory == nil {
+							return fmt.Errorf("action factory '%s' referenced by trigger [%s]'s handler [%s], has not been registered\"", ref, tConfig.Id, hConfig.Name)
+						}
+
+						act, err := actionFactory.New(act.Config)
+						if err != nil {
+							return fmt.Errorf("error creating action [%s] for trigger [%s]'s handler [%s]\"", ref, tConfig.Id, hConfig.Name)
+						}
+
+						acts = append(acts, act)
+					}
+				}
+			}
+
+			// Resolve schema references
+			if hConfig.Schemas != nil {
+				if out := hConfig.Schemas.Output; out != nil {
+					for name, def := range out {
+						ref, ok := def.(string)
+						if ok {
+							s, err := schema.FindOrCreate(ref)
+							if err != nil {
+								return fmt.Errorf("unable to find or create output schema [%s] for trigger [%s]'s handler [%s]: %s", ref, tConfig.Id, hConfig.Name, err.Error())
+							}
+							hConfig.Schemas.Output[name] = s
+						}
+					}
+				}
+
+				if reply := hConfig.Schemas.Reply; reply != nil {
+					for name, def := range reply {
+						ref, ok := def.(string)
+						if ok {
+							s, err := schema.FindOrCreate(ref)
+							if err != nil {
+								return fmt.Errorf("unable to find or create reply schema [%s] in trigger [%s]'s handler [%s]: %s", ref, tConfig.Id, hConfig.Name, err.Error())
+							}
+							hConfig.Schemas.Reply[name] = s
+						}
+					}
+				}
+			}
+
+			handler, err := trigger.NewHandler(hConfig, acts, mapperFactory, expressionFactory, runner, logger)
+			if err != nil {
+				return fmt.Errorf("error creating handler [%s] in trigger [%s]:%s", hConfig.Name, tConfig.Id, err.Error())
+			}
+
+			initCtx.handlers = append(initCtx.handlers, handler)
+		}
+		trigger.PostTriggerEvent(trigger.INITIALIZING, tConfig.Id)
+		err = trg.Initialize(initCtx)
+		if err != nil {
+			trigger.PostTriggerEvent(trigger.INIT_FAILED, tConfig.Id)
+			return fmt.Errorf("error initializing trigger [%s]:%s", tConfig.Id, err.Error())
+		}
+		trigger.PostTriggerEvent(trigger.INITIALIZED, tConfig.Id)
+		for _, t := range a.triggers {
+			if t.id == tConfig.Id {
+				// Update trigger instance
+				t.trg = trg
+				break
+			}
+		}
+	}
+	return nil
+}
 
 type initContext struct {
 	handlers []trigger.Handler

--- a/app/resource/manager.go
+++ b/app/resource/manager.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"strings"
 
 	"github.com/project-flogo/core/support"
@@ -77,19 +78,29 @@ func (m *Manager) CleanupResources() {
 	}
 }
 
-func (m *Manager) ReconfigureResources(resConfigs []*Config) error {
+func (m *Manager) ReconfigureResources(resConfigs []*Config) (err error) {
+	defer func() {
+		// Handle panic in implementation code
+		if r := recover(); r != nil {
+			log.RootLogger().Errorf("Unhandled error while reconfiguring resource: %v", r)
+			if log.RootLogger().DebugEnabled() {
+				log.RootLogger().Debugf("StackTrace: %s", debug.Stack())
+			}
+			err = fmt.Errorf("Unhandled error while reconfiguring resource: %v", r)
+		}
+	}()
 	for _, resConfig := range resConfigs {
 		resource := m.GetResource(resConfig.ID)
 		if resource != nil {
 			if reconfigurableRes, ok := resource.Object().(ReconfigurableResource); ok {
-				err := reconfigurableRes.Reconfigure(resConfig)
+				err = reconfigurableRes.Reconfigure(resConfig)
 				if err != nil {
 					return fmt.Errorf("Failed to reconfigure resource: [%s] due to error: %v : ", resConfig.ID, err)
 				}
 			}
 		}
 	}
-	return nil
+	return err
 }
 
 func GetTypeFromID(id string) (string, error) {

--- a/app/resource/resource.go
+++ b/app/resource/resource.go
@@ -5,6 +5,10 @@ type Resource struct {
 	resObj  interface{}
 }
 
+type ReconfigurableResource interface {
+	Reconfigure(config *Config) error
+}
+
 func New(resType string, resObj interface{}) *Resource {
 	return &Resource{resType: resType, resObj: resObj}
 }

--- a/support/connection/manager.go
+++ b/support/connection/manager.go
@@ -2,13 +2,15 @@ package connection
 
 import (
 	"fmt"
+	
+	"github.com/project-flogo/core/support/managed"
 )
 
 type Manager interface {
 	Type() string
-
+	
 	GetConnection() interface{}
-
+	
 	ReleaseConnection(connection interface{})
 }
 
@@ -19,45 +21,90 @@ type ReconfigurableManager interface {
 
 type ManagerFactory interface {
 	Type() string
-
+	
 	NewManager(settings map[string]interface{}) (Manager, error)
 }
 
 func NewManager(config *Config) (Manager, error) {
-
+	
 	//resolve settings
 	err := ResolveConfig(config)
 	if err != nil {
 		return nil, err
 	}
-
+	
 	f := GetManagerFactory(config.Ref)
-
+	
 	if f == nil {
 		return nil, fmt.Errorf("connection factory '%s' not registered", config.Ref)
 	}
-
+	
 	cm, err := f.NewManager(config.Settings)
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return cm, err
 }
 
 func NewSharedManager(id string, config *Config) (Manager, error) {
-
+	
 	cm, err := NewManager(config)
 	if err != nil {
 		return nil, err
 	}
-
+	
 	err = RegisterManager(id, cm)
 	if err != nil {
 		return nil, err
 	}
-
+	
 	return cm, err
+}
+
+func ReconfigureManager(id string, config *Config) error {
+	manager := managers[id]
+	if manager == nil {
+		return fmt.Errorf("connection not found for id '%s'", id)
+	}
+	var err error
+	// Resolve connection configuration
+	err = ResolveConfig(config)
+	if err != nil {
+		return err
+	}
+	
+	reconfigurableConn, ok := manager.(ReconfigurableManager)
+	if ok {
+		// Update existing connection instance
+		err = reconfigurableConn.ReconfigureConnection(config.Settings)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Create new connection instance
+		m, isManaged := manager.(managed.Managed)
+		if isManaged {
+			// Stop previous connection instance
+			err = m.Stop()
+			if err != nil {
+				return err
+			}
+			// Create new connection instance
+			manager, err = NewManager(config)
+			if err != nil {
+				return err
+			}
+			// Start new connection instance
+			err = manager.(managed.Managed).Start()
+			if err != nil {
+				return err
+			}
+			// Replace existing instance with new instance
+			managers[id] = manager
+		}
+	}
+	return nil
 }
 
 func IsShared(manager Manager) bool {

--- a/support/connection/manager.go
+++ b/support/connection/manager.go
@@ -14,7 +14,7 @@ type Manager interface {
 
 // Connections that support dynamic updates
 type ReconfigurableManager interface {
-	Reconfigure(settings map[string]interface{}) error
+	ReconfigureConnection(settings map[string]interface{}) error
 }
 
 type ManagerFactory interface {

--- a/support/connection/manager.go
+++ b/support/connection/manager.go
@@ -12,13 +12,18 @@ type Manager interface {
 	ReleaseConnection(connection interface{})
 }
 
+// Connections that support dynamic updates
+type ReconfigurableManager interface {
+	Reconfigure(settings map[string]interface{}) error
+}
+
 type ManagerFactory interface {
 	Type() string
 
 	NewManager(settings map[string]interface{}) (Manager, error)
 }
 
-func NewManager(config *Config) (Manager, error)  {
+func NewManager(config *Config) (Manager, error) {
 
 	//resolve settings
 	err := ResolveConfig(config)
@@ -40,7 +45,7 @@ func NewManager(config *Config) (Manager, error)  {
 	return cm, err
 }
 
-func NewSharedManager(id string, config *Config) (Manager, error)  {
+func NewSharedManager(id string, config *Config) (Manager, error) {
 
 	cm, err := NewManager(config)
 	if err != nil {
@@ -55,7 +60,7 @@ func NewSharedManager(id string, config *Config) (Manager, error)  {
 	return cm, err
 }
 
-func IsShared(manager Manager) bool{
+func IsShared(manager Manager) bool {
 	for _, mgr := range managers {
 		if manager == mgr {
 			return true
@@ -63,4 +68,3 @@ func IsShared(manager Manager) bool{
 	}
 	return false
 }
-

--- a/support/connection/registry.go
+++ b/support/connection/registry.go
@@ -82,18 +82,6 @@ func RegisterManager(connectionId string, manager Manager) error {
 	return nil
 }
 
-func UnregisterManager(connectionId string) error {
-	if connectionId == "" {
-		return fmt.Errorf("'id' must be specified when unregistering")
-	}
-	if _, found := managers[connectionId]; !found {
-		return fmt.Errorf("connection manager not registered: %s", connectionId)
-	}
-	log.RootLogger().Debugf("Unregistering connection manager: %s", connectionId)
-	delete(managers, connectionId)
-	return nil
-}
-
 func GetManager(id string) Manager {
 	return managers[id]
 }

--- a/support/connection/registry.go
+++ b/support/connection/registry.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	managerFactories = make(map[string]ManagerFactory)
-	managers = make(map[string]Manager)
+	managers         = make(map[string]Manager)
 )
 
 func RegisterManagerFactory(factory ManagerFactory) error {
@@ -26,7 +26,7 @@ func RegisterManagerFactory(factory ManagerFactory) error {
 
 	managerFactories[ref] = factory
 
-	log.RootLogger().Debugf("Registering '%s' connection manager factory: %s", factory.Type(), ref )
+	log.RootLogger().Debugf("Registering '%s' connection manager factory: %s", factory.Type(), ref)
 
 	return nil
 }
@@ -43,18 +43,17 @@ func ReplaceManagerFactory(ref string, factory ManagerFactory) error {
 
 	managerFactories[ref] = factory
 
-	log.RootLogger().Debugf("Replacing '%s' connection manager factory: %s", factory.Type, ref )
+	log.RootLogger().Debugf("Replacing '%s' connection manager factory: %s", factory.Type, ref)
 
 	return nil
 }
-
 
 func GetManagerFactory(ref string) ManagerFactory {
 	return managerFactories[ref]
 }
 
 func ManagerFactories() map[string]ManagerFactory {
-	ret := make(map[string]ManagerFactory,len(managerFactories) )
+	ret := make(map[string]ManagerFactory, len(managerFactories))
 	for id, managerFactory := range managerFactories {
 		ret[id] = managerFactory
 	}
@@ -83,12 +82,24 @@ func RegisterManager(connectionId string, manager Manager) error {
 	return nil
 }
 
+func UnregisterManager(connectionId string) error {
+	if connectionId == "" {
+		return fmt.Errorf("'id' must be specified when unregistering")
+	}
+	if _, found := managers[connectionId]; !found {
+		return fmt.Errorf("connection manager not registered: %s", connectionId)
+	}
+	log.RootLogger().Debugf("Unregistering connection manager: %s", connectionId)
+	delete(managers, connectionId)
+	return nil
+}
+
 func GetManager(id string) Manager {
 	return managers[id]
 }
 
 func Managers() map[string]Manager {
-	ret := make(map[string]Manager,len(managers) )
+	ret := make(map[string]Manager, len(managers))
 	for id, manager := range managers {
 		ret[id] = manager
 	}

--- a/trigger/trigger.go
+++ b/trigger/trigger.go
@@ -14,6 +14,12 @@ type Trigger interface {
 	Initialize(ctx InitContext) error
 }
 
+// ReconfigurableTrigger is object that supports dynamic reconfiguration of trigger
+type ReconfigurableTrigger interface {
+	// Reconfigure is called to reconfigure trigger implementation
+	Reconfigure(config *Config, handlers []Handler) error
+}
+
 // InitContext is the initialization context for the trigger instance
 type InitContext interface {
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
In some cases, users would like to auto reconfigure app without restarting engine. The updated value could be used in triggers/connections/activities settings. Currently, engine restart is the only way to force trigger/connection/activity settings be reconfigured with new values.

**What is the new behavior?**
With new features, trigger/connection/activity can act on updated configuration by implementing additional interface. When reconfiguration is triggered through REST API (manually) or configuration management SDK(automatically), implementors can use new configuration to recreate/update technology specific object they hold. e.g. REST activity can reinitialize HTTP client with new certificate retrieved from config management service.