### PR TITLE
fix shared data delete due to concurrent map writes

### DIFF
--- a/data/scope.go
+++ b/data/scope.go
@@ -93,11 +93,11 @@ func (s *SimpleSyncScope) GetValue(name string) (value interface{}, exists bool)
 
 // Delete implements Scope.GetValue
 func (s *SimpleSyncScope) Delete(name string) {
-	s.mutex.RLock()
+	s.mutex.Lock()
 	if delScope, ok := s.scope.(NeedsDelete); ok {
 		delScope.Delete(name)
 	}
-	s.mutex.RUnlock()
+	s.mutex.Unlock()
 }
 
 // SetValue implements Scope.SetValue


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #
Concurrent map write issue when deleting a key from shared data simple sync scope

**What is the current behavior?**
Getting a fatal error when multiple requests are being handled for getting and deleting values from sync scope

**What is the new behavior?**
Now able to handle multiple requests for getting and deleting the values from sync scope are successful