### PR TITLE
Activity name in context

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -7,10 +7,10 @@ import (
 
 // Activity is an interface for defining a custom Activity Execution
 type Activity interface {
-
+	
 	// Metadata returns the metadata of the activity
 	Metadata() *Metadata
-
+	
 	// Eval is called when an Activity is being evaluated.  Returning true indicates
 	// that the task is done.
 	Eval(ctx Context) (done bool, err error)
@@ -19,16 +19,19 @@ type Activity interface {
 type Factory func(ctx InitContext) (Activity, error)
 
 type InitContext interface {
-
+	
 	// Settings
 	Settings() map[string]interface{}
-
+	
 	// MapperFactory gets the mapper factory associated with the activity host
 	MapperFactory() mapper.Factory
-
+	
 	// Logger logger to using during initialization, activity implementations should not
 	// keep a reference to this
 	Logger() log.Logger
+	
+	// Name returns name of the activity
+	Name() string
 }
 
 type Details struct {

--- a/api/support.go
+++ b/api/support.go
@@ -2,11 +2,12 @@ package api
 
 import (
 	"context"
-	"github.com/project-flogo/core/support/log"
-	"github.com/project-flogo/core/support/trace"
 	"reflect"
 	"strconv"
 	"strings"
+
+	"github.com/project-flogo/core/support/log"
+	"github.com/project-flogo/core/support/trace"
 
 	"github.com/project-flogo/core/action"
 	"github.com/project-flogo/core/activity"
@@ -188,6 +189,10 @@ func (ctx *initCtx) MapperFactory() mapper.Factory {
 
 func (ctx *initCtx) Logger() log.Logger {
 	return log.RootLogger()
+}
+
+func (ctx *initCtx) Name() string {
+	return ""
 }
 
 var activityLogger = log.ChildLogger(log.RootLogger(), "activity")

--- a/support/test/context.go
+++ b/support/test/context.go
@@ -67,9 +67,27 @@ func NewActivityInitContext(settings interface{}, f mapper.Factory) activity.Ini
 	return &TestActivityInitContext{settings: settingVals, factory: f}
 }
 
+func NewActivityInitContextWithName(settings interface{}, f mapper.Factory, name string) activity.InitContext {
+
+	var settingVals map[string]interface{}
+
+	if sm, ok := settings.(map[string]interface{}); ok {
+		settingVals = sm
+	} else {
+		settingVals = metadata.StructToMap(settings)
+	}
+
+	if f == nil {
+		f = mapper.NewFactory(resolve.GetBasicResolver())
+	}
+
+	return &TestActivityInitContext{settings: settingVals, factory: f, name: name}
+}
+
 type TestActivityInitContext struct {
 	settings map[string]interface{}
 	factory  mapper.Factory
+	name     string
 }
 
 func (ic *TestActivityInitContext) Settings() map[string]interface{} {
@@ -82,6 +100,9 @@ func (ic *TestActivityInitContext) MapperFactory() mapper.Factory {
 
 func (ic *TestActivityInitContext) Logger() log.Logger {
 	return logger
+}
+func (ic *TestActivityInitContext) Name() string {
+	return ic.name
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently activity name is not available in the [InitContext](https://github.com/project-flogo/core/blob/master/activity/activity.go#L21). Due to this, activity name can not be used during initialization. e.g. Pulsar producer name
**What is the new behavior?**
With this change, contribution developers can access activity name during initialization.