### PR TITLE
add hostname in the initContext

### DIFF
--- a/activity/activity.go
+++ b/activity/activity.go
@@ -7,10 +7,10 @@ import (
 
 // Activity is an interface for defining a custom Activity Execution
 type Activity interface {
-	
+
 	// Metadata returns the metadata of the activity
 	Metadata() *Metadata
-	
+
 	// Eval is called when an Activity is being evaluated.  Returning true indicates
 	// that the task is done.
 	Eval(ctx Context) (done bool, err error)
@@ -19,19 +19,21 @@ type Activity interface {
 type Factory func(ctx InitContext) (Activity, error)
 
 type InitContext interface {
-	
+
 	// Settings
 	Settings() map[string]interface{}
-	
+
 	// MapperFactory gets the mapper factory associated with the activity host
 	MapperFactory() mapper.Factory
-	
+
 	// Logger logger to using during initialization, activity implementations should not
 	// keep a reference to this
 	Logger() log.Logger
-	
-	// Name returns name of the activity
+
+	// Name returns name of the activity / task
 	Name() string
+	// HostName returns name of the flow / task host
+	HostName() string
 }
 
 type Details struct {

--- a/api/support.go
+++ b/api/support.go
@@ -195,6 +195,10 @@ func (ctx *initCtx) Name() string {
 	return ""
 }
 
+func (ctx *initCtx) HostName() string {
+	return ""
+}
+
 var activityLogger = log.ChildLogger(log.RootLogger(), "activity")
 
 // EvalActivity evaluates the specified activity using the provided inputs

--- a/support/test/context.go
+++ b/support/test/context.go
@@ -88,6 +88,7 @@ type TestActivityInitContext struct {
 	settings map[string]interface{}
 	factory  mapper.Factory
 	name     string
+	hostName string
 }
 
 func (ic *TestActivityInitContext) Settings() map[string]interface{} {
@@ -101,8 +102,13 @@ func (ic *TestActivityInitContext) MapperFactory() mapper.Factory {
 func (ic *TestActivityInitContext) Logger() log.Logger {
 	return logger
 }
+
 func (ic *TestActivityInitContext) Name() string {
 	return ic.name
+}
+
+func (ic *TestActivityInitContext) HostName() string {
+	return ic.hostName
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
Currently activity host name is not available in the [InitContext](https://github.com/project-flogo/core/blob/master/activity/activity.go#L21). Due to this, activity host name can not be used during initialization. e.g. Pulsar producer name

**What is the new behavior?**
With this change, contribution developers can access activity host name during initialization.