### PR TITLE
added logic to print logs for pause and resume triggers

### DIFF
--- a/app/controller.go
+++ b/app/controller.go
@@ -79,42 +79,37 @@ func (a *App) initEventFlowController() {
 // Start triggers
 func (c *controllerData) resumeTriggers() error {
 	// Resume  triggers
-	logger.Info("Resuming Triggers...")
 	for id, trg := range c.triggers {
-		var err error
 		if flowControlAware, ok := trg.(trigger.EventFlowControlAware); ok {
-			err = flowControlAware.Resume()
+			logger.Info("Resuming Triggers...")
+			err := flowControlAware.Resume()
+			if err != nil {
+				//return err
+				//TODO Starting other triggers. Should we stop the app here?
+				logger.Errorf("Trigger [%s] failed to resume due to error - %s.", id, err.Error())
+				continue
+			}
+			logger.Infof("Trigger [%s] is resumed.", id)
 		}
-
-		if err != nil {
-			//return err
-			//TODO Starting other triggers. Should we stop the app here?
-			logger.Errorf("Trigger [%s] failed to resume due to error - %s.", id, err.Error())
-			continue
-		}
-		logger.Infof("Trigger [%s] is resumed.", id)
 	}
-	logger.Info("Triggers are resumed")
 	return nil
 }
 
 // Stop triggers
 func (c *controllerData) pauseTriggers() error {
-	logger.Info("Pausing Triggers...")
 	// Pause Triggers
 	for id, trg := range c.triggers {
-		var err error
 		if flowControlAware, ok := trg.(trigger.EventFlowControlAware); ok {
-			err = flowControlAware.Pause()
+			logger.Info("Pausing Triggers...")
+			err := flowControlAware.Pause()
+			if err != nil {
+				//return err
+				//TODO Stopping other triggers. Should we stop the app here?
+				logger.Errorf("Trigger [%s] failed to pause due to error - %s.", id, err.Error())
+				continue
+			}
+			logger.Infof("Trigger [%s] is paused.", id)
 		}
-		if err != nil {
-			//return err
-			//TODO Stopping other triggers. Should we stop the app here?
-			logger.Errorf("Trigger [%s] failed to pause due to error - %s.", id, err.Error())
-			continue
-		}
-		logger.Infof("Trigger [%s] is paused.", id)
 	}
-	logger.Info("Triggers are paused")
 	return nil
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #
Added logic to print logs for while pausing and resuming functions when flow control is enabled.
**What is the current behavior?**
Pause and resume logs are printed irrespective if the trigger is flow controlled or not.
**What is the new behavior?**
Pause and resume will be called when the trigger is flow controlled.