### PR TITLE
Read the value of logger output path from environment variable if set

### DIFF
--- a/support/log/logger.go
+++ b/support/log/logger.go
@@ -32,6 +32,7 @@ const (
 
 	EnvKeyLogSeparator  = "FLOGO_LOG_SEPARATOR"
 	DefaultLogSeparator = "\t"
+	EnvLogConsoleStream = "FLOGO_LOG_CONSOLE_STREAM"
 )
 
 type Level int

--- a/support/log/zap.go
+++ b/support/log/zap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"os"
 )
 
 var traceLogger *zap.SugaredLogger
@@ -158,8 +159,15 @@ func newZapLogger(logFormat Format, level Level) (*zap.Logger, *zap.AtomicLevel,
 	cfg := zap.NewProductionConfig()
 	cfg.DisableCaller = true
 
-	cfg.OutputPaths = []string{"stdout"}
-	
+	// change the default output paths for the logger if the env variable is set and has the supported values (stderr and stdout).
+	// Otherwise, the logger will use the default value of stderr.
+	logstream, ok := os.LookupEnv(EnvLogConsoleStream)
+	if ok {
+		if logstream == "stdout" || logstream == "stderr" {
+			cfg.OutputPaths = []string{logstream}
+		}
+	}
+
 	eCfg := cfg.EncoderConfig
 	eCfg.TimeKey = "timestamp"
 	eCfg.EncodeTime = zapcore.ISO8601TimeEncoder

--- a/support/log/zap.go
+++ b/support/log/zap.go
@@ -5,6 +5,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"os"
+	"strings"
 )
 
 var traceLogger *zap.SugaredLogger
@@ -163,8 +164,8 @@ func newZapLogger(logFormat Format, level Level) (*zap.Logger, *zap.AtomicLevel,
 	// Otherwise, the logger will use the default value of stderr.
 	logstream, ok := os.LookupEnv(EnvLogConsoleStream)
 	if ok {
-		if logstream == "stdout" || logstream == "stderr" {
-			cfg.OutputPaths = []string{logstream}
+		if strings.ToLower(logstream) == "stdout" || strings.ToLower(logstream) == "stderr" {
+			cfg.OutputPaths = []string{strings.ToLower(logstream)}
 		}
 	}
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #
Instead of setting the logger output path to stdout read the value from environment variable.

**What is the current behavior?**
The default output path is set to stdout. This might break the backward compatibility of the existing projects.

**What is the new behavior?**
Set the output path only if the the environment variable FLOGO_LOG_CONSOLE_STREAM is set and provides the support values (stdout and stderr)
