### PR TITLE
FLOGO-17735: add traceID and spanID attributes to log message

### DIFF
--- a/support/log/logger.go
+++ b/support/log/logger.go
@@ -3,6 +3,7 @@ package log
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -31,9 +32,16 @@ const (
 	EnvKeyLogFormat      = "FLOGO_LOG_FORMAT"
 	DefaultLogFormat     = FormatConsole
 
-	EnvKeyLogSeparator  = "FLOGO_LOG_SEPARATOR"
-	DefaultLogSeparator = "\t"
-	EnvLogConsoleStream = "FLOGO_LOG_CONSOLE_STREAM"
+	EnvKeyLogSeparator              = "FLOGO_LOG_SEPARATOR"
+	DefaultLogSeparator             = "\t"
+	EnvLogConsoleStream             = "FLOGO_LOG_CONSOLE_STREAM"
+	EnvLogTracingContextEnabled     = "FLOGO_LOG_TRACE_CTX_ENABLED"
+	DefaultLogTracingContextEnabled = true
+)
+
+const (
+	KeyTraceID = "traceID"
+	KeySpanID  = "spanID"
 )
 
 type Level int
@@ -56,6 +64,9 @@ type Logger interface {
 	Errorf(template string, args ...interface{})
 
 	Structured() StructuredLogger
+	// FLOGO-17735: add traceID and spanID attributes to log message
+	GetTracingContext() map[string]string
+	SetTracingContext(traceContext map[string]string)
 }
 
 type StructuredLogger interface {
@@ -68,8 +79,9 @@ type StructuredLogger interface {
 type Field = interface{}
 
 var (
-	rootLogger Logger
-	ctxLogging bool
+	rootLogger          Logger
+	ctxLogging          bool
+	traceContextLogging bool
 )
 
 func init() {
@@ -191,6 +203,7 @@ func configureLogging() {
 	if strings.ToLower(envLogCtx) == "true" {
 		ctxLogging = true
 	}
+	traceContextLogging = getTraceCtxEnabled()
 
 	rootLogLevel := DefaultLogLevel
 
@@ -268,4 +281,16 @@ func getLogSeparator() string {
 		return v
 	}
 	return DefaultLogSeparator
+}
+
+func getTraceCtxEnabled() bool {
+	v, ok := os.LookupEnv(EnvLogTracingContextEnabled)
+	if !ok {
+		return DefaultLogTracingContextEnabled
+	}
+	enabled, err := strconv.ParseBool(v)
+	if err != nil {
+		return DefaultLogTracingContextEnabled
+	}
+	return enabled
 }

--- a/support/log/zap.go
+++ b/support/log/zap.go
@@ -2,10 +2,11 @@ package log
 
 import (
 	"fmt"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"os"
 	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var traceLogger *zap.SugaredLogger
@@ -13,6 +14,9 @@ var traceLogger *zap.SugaredLogger
 type zapLoggerImpl struct {
 	loggerLevel *zap.AtomicLevel
 	mainLogger  *zap.SugaredLogger
+	// FLOGO-17735: add traceID and spanID attributes to log message
+	tracePrefix  string
+	traceContext map[string]string
 }
 
 func (l *zapLoggerImpl) DebugEnabled() bool {
@@ -23,52 +27,108 @@ func (l *zapLoggerImpl) TraceEnabled() bool {
 	return traceEnabled && l.loggerLevel.Enabled(zapcore.DebugLevel)
 }
 
-func (l *zapLoggerImpl) Trace(args ...interface{}) {
+func (l *zapLoggerImpl) Trace(args ...any) {
 	if traceEnabled {
 		traceLogger.Debug(args...)
 	}
 }
 
-func (l *zapLoggerImpl) Debug(args ...interface{}) {
-	l.mainLogger.Debug(args...)
+func (l *zapLoggerImpl) Debug(args ...any) {
+	if l.tracePrefix != "" {
+		s := make([]any, 1, 1+len(args))
+		s[0] = l.tracePrefix
+		l.mainLogger.Debug(append(s, args...)...)
+	} else {
+		l.mainLogger.Debug(args...)
+	}
 }
 
-func (l *zapLoggerImpl) Info(args ...interface{}) {
-	l.mainLogger.Info(args...)
+func (l *zapLoggerImpl) Info(args ...any) {
+	if l.tracePrefix != "" {
+		s := make([]any, 1, 1+len(args))
+		s[0] = l.tracePrefix
+		l.mainLogger.Info(append(s, args...)...)
+	} else {
+		l.mainLogger.Info(args...)
+	}
 }
 
-func (l *zapLoggerImpl) Warn(args ...interface{}) {
-	l.mainLogger.Warn(args...)
+func (l *zapLoggerImpl) Warn(args ...any) {
+	if l.tracePrefix != "" {
+		s := make([]any, 1, 1+len(args))
+		s[0] = l.tracePrefix
+		l.mainLogger.Warn(append(s, args...)...)
+	} else {
+		l.mainLogger.Warn(args...)
+	}
 }
 
-func (l *zapLoggerImpl) Error(args ...interface{}) {
-	l.mainLogger.Error(args...)
+func (l *zapLoggerImpl) Error(args ...any) {
+	if l.tracePrefix != "" {
+		s := make([]any, 1, 1+len(args))
+		s[0] = l.tracePrefix
+		l.mainLogger.Error(append(s, args...)...)
+	} else {
+		l.mainLogger.Error(args...)
+	}
 }
 
-func (l *zapLoggerImpl) Tracef(template string, args ...interface{}) {
+func (l *zapLoggerImpl) Tracef(template string, args ...any) {
 	if traceEnabled {
 		traceLogger.Debugf(template, args...)
 	}
 }
 
-func (l *zapLoggerImpl) Debugf(template string, args ...interface{}) {
-	l.mainLogger.Debugf(template, args...)
+func (l *zapLoggerImpl) Debugf(template string, args ...any) {
+	if l.tracePrefix != "" {
+		l.mainLogger.Debugf(l.tracePrefix+template, args...)
+	} else {
+		l.mainLogger.Debugf(template, args...)
+	}
 }
 
-func (l *zapLoggerImpl) Infof(template string, args ...interface{}) {
-	l.mainLogger.Infof(template, args...)
+func (l *zapLoggerImpl) Infof(template string, args ...any) {
+	if l.tracePrefix != "" {
+		l.mainLogger.Infof(l.tracePrefix+template, args...)
+	} else {
+		l.mainLogger.Infof(template, args...)
+	}
 }
 
-func (l *zapLoggerImpl) Warnf(template string, args ...interface{}) {
-	l.mainLogger.Warnf(template, args...)
+func (l *zapLoggerImpl) Warnf(template string, args ...any) {
+	if l.tracePrefix != "" {
+		l.mainLogger.Warnf(l.tracePrefix+template, args...)
+	} else {
+		l.mainLogger.Warnf(template, args...)
+	}
 }
 
-func (l *zapLoggerImpl) Errorf(template string, args ...interface{}) {
-	l.mainLogger.Errorf(template, args...)
+func (l *zapLoggerImpl) Errorf(template string, args ...any) {
+	if l.tracePrefix != "" {
+		l.mainLogger.Errorf(l.tracePrefix+template, args...)
+	} else {
+		l.mainLogger.Errorf(template, args...)
+	}
 }
 
 func (l *zapLoggerImpl) Structured() StructuredLogger {
 	return &zapStructuredLoggerImpl{zl: l.mainLogger.Desugar()}
+}
+
+func (l *zapLoggerImpl) GetTracingContext() map[string]string {
+	return l.traceContext
+}
+
+func (l *zapLoggerImpl) SetTracingContext(traceContext map[string]string) {
+	if !traceContextLogging {
+		return
+	}
+	l.traceContext = traceContext
+	if traceContext != nil && traceContext[KeyTraceID] != "" {
+		l.tracePrefix = fmt.Sprintf("[%s: %s] [%s: %s] ", KeyTraceID, traceContext[KeyTraceID], KeySpanID, traceContext[KeySpanID])
+	} else {
+		l.tracePrefix = ""
+	}
 }
 
 type zapStructuredLoggerImpl struct {

--- a/support/trace/context.go
+++ b/support/trace/context.go
@@ -39,3 +39,13 @@ func ExtractTracingContext(goCtx context.Context) TracingContext {
 	tc, _ := goCtx.Value(id).(TracingContext)
 	return tc
 }
+
+func GetContextForLogger(tracingContext TracingContext) map[string]string {
+	if tracingContext == nil {
+		return nil
+	}
+	return map[string]string{
+		log.KeyTraceID: tracingContext.TraceID(),
+		log.KeySpanID:  tracingContext.SpanID(),
+	}
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[] Bugfix
[x] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**What is the current behavior?**
When tracing is enabled, the log statements do not have the traceID and spanID in them, so it's very difficult to debug the issue based on the traceID.

**What is the new behavior?**
When tracing is enabled, the log statements now include the current traceID and spanID. For example:
```
2026-03-25T12:00:50.645+0530    INFO    [flogo.flow] -  [traceID: a2a162eb7534edf8bc860638184eb6a4] [spanID: cd12ad8e96d8aabe] Flow Instance [86cf586ee9e6c5c97f347031e623120a] for event id [AE079D8100237AA0467965FA] completed in 152.9553ms
```

This new behavior is turned on by default, if you wish to disable injecting the traceID and spanID in the log statements, you can set the following env variable to `false`. By default the value for this variable is `true`
```
export FLOGO_LOG_TRACE_CTX_ENABLED=false
```