### PR TITLE
FLOGO-17532: Handle duplicate alias issue

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -627,6 +627,7 @@ func registerImport(anImport string) error {
 
 	var alias string
 	var ref string
+	var explicitAlias bool
 	numParts := len(parts)
 	if numParts == 1 {
 		ref = parts[0]
@@ -634,6 +635,7 @@ func registerImport(anImport string) error {
 	} else if numParts == 2 {
 		alias = parts[0]
 		ref = parts[1]
+		explicitAlias = true
 	} else {
 		return fmt.Errorf("invalid import %s", anImport)
 	}
@@ -653,6 +655,11 @@ func registerImport(anImport string) error {
 	log.RootLogger().Debugf("Registering type alias '%s' for %s [%s]", alias, ct, ref)
 
 	err := support.RegisterAlias(ct, alias, ref)
+	if err != nil && !explicitAlias {
+		alias = resolveAliasConflict(ref, alias, ct)
+		log.RootLogger().Debugf("Auto-resolved alias collision, using '%s' for %s [%s]", alias, ct, ref)
+		err = support.RegisterAlias(ct, alias, ref)
+	}
 	if err != nil {
 		return err
 	}
@@ -662,6 +669,22 @@ func registerImport(anImport string) error {
 	}
 
 	return nil
+}
+
+func resolveAliasConflict(ref, baseAlias, contribType string) string {
+	grandparent := path.Base(path.Dir(path.Dir(ref)))
+	if grandparent != "." && grandparent != "" {
+		candidate := grandparent + "_" + baseAlias
+		if !support.AliasExists(contribType, candidate) {
+			return candidate
+		}
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%d", baseAlias, i)
+		if !support.AliasExists(contribType, candidate) {
+			return candidate
+		}
+	}
 }
 
 func getContribType(ref string) string {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/project-flogo/core/examples/action"
 	_ "github.com/project-flogo/core/examples/trigger"
+	"github.com/project-flogo/core/support"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,4 +67,61 @@ func TestApp(t *testing.T) {
 
 	err = app.Stop()
 	assert.Nil(t, err)
+}
+
+func TestResolveAliasConflict_GrandparentUnique(t *testing.T) {
+	ref := "github.com/org/contrib/activity/query"
+	result := resolveAliasConflict(ref, "query", "type1")
+	assert.Equal(t, "contrib_query", result)
+}
+
+func TestResolveAliasConflict_GrandparentAlsoTaken(t *testing.T) {
+	_ = support.RegisterAlias("type2", "contrib_query", "some/other/ref")
+
+	ref := "github.com/org/contrib/activity/query"
+	result := resolveAliasConflict(ref, "query", "type2")
+	assert.Equal(t, "query_2", result)
+}
+
+func TestResolveAliasConflict_NumericFallbackSkipsTaken(t *testing.T) {
+	_ = support.RegisterAlias("type3", "contrib_query", "some/other/ref")
+	_ = support.RegisterAlias("type3", "query_2", "another/ref")
+	_ = support.RegisterAlias("type3", "query_3", "yet/another/ref")
+
+	ref := "github.com/org/contrib/activity/query"
+	result := resolveAliasConflict(ref, "query", "type3")
+	assert.Equal(t, "query_4", result)
+}
+
+func TestResolveAliasConflict_ShallowRefNoGrandparent(t *testing.T) {
+	ref := "query"
+	result := resolveAliasConflict(ref, "query", "type4")
+	assert.Equal(t, "query_2", result)
+}
+
+func TestResolveAliasConflict_SingleSegmentParent(t *testing.T) {
+	ref := "activity/query"
+	result := resolveAliasConflict(ref, "query", "type5")
+	assert.Equal(t, "query_2", result)
+}
+
+func TestResolveAliasConflict_DifferentContribTypes(t *testing.T) {
+	_ = support.RegisterAlias("type6_other", "activity_log", "some/trigger/ref")
+
+	ref := "github.com/org/contrib/activity/log"
+	result := resolveAliasConflict(ref, "log", "type6")
+	assert.Equal(t, "contrib_log", result)
+}
+
+func TestResolveAliasConflict_NumericStartsAt2(t *testing.T) {
+	_ = support.RegisterAlias("type7", "contrib_query", "some/ref")
+
+	ref := "github.com/org/contrib/activity/query"
+	result := resolveAliasConflict(ref, "query", "type7")
+	assert.Equal(t, "query_2", result)
+}
+
+func TestResolveAliasConflict_EmptyRef(t *testing.T) {
+	result := resolveAliasConflict("", "query", "type8")
+	assert.Equal(t, "query_2", result)
 }

--- a/support/alias.go
+++ b/support/alias.go
@@ -21,6 +21,15 @@ func RegisterAlias(contribType, alias, ref string) error {
 	return nil
 }
 
+func AliasExists(contribType, alias string) bool {
+	aliasToRefMap, exists := aliases[contribType]
+	if !exists {
+		return false
+	}
+	_, exists = aliasToRefMap[alias]
+	return exists
+}
+
 func GetAliasRef(contribType, alias string) (string, bool) {
 
 	if alias == "" {

--- a/support/alias_test.go
+++ b/support/alias_test.go
@@ -37,6 +37,16 @@ func TestGetAliasRef(t *testing.T) {
 	}
 }
 
+func TestAliasExists(t *testing.T) {
+	aliases = make(map[string]map[string]string)
+	aliases["activity"] = make(map[string]string)
+	aliases["activity"]["query"] = "github.com/tibco/wi-postgres/src/app/PostgreSQL/activity/query"
+
+	assert.True(t, AliasExists("activity", "query"))
+	assert.False(t, AliasExists("activity", "nonexistent"))
+	assert.False(t, AliasExists("connection", "query"))
+}
+
 func TestRegisterAlias(t *testing.T) {
 	aliases = make(map[string]map[string]string)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: #

**What is the current behavior?**
When multiple database contributions (PostgreSQL, MySQL, MSSQL, TDV) are used in a single Flogo app, the runtime logs ERROR messages at startup because their import paths share the same last segment (query for activities, connection for connectors). The registerImport function derives the alias using path.Base(), which produces the same alias for all of them. The first import registers successfully, but all subsequent imports with the same alias fail with:
`
ERROR [flogo] - cannot register import 'github.com/tibco/wi-mssql/src/app/SQLServer/connector/connection' : alias 'connection' for connection already registered
ERROR [flogo] - cannot register import 'github.com/tibco/wi-mysql/src/app/MySQL/activity/query' : alias 'query' for activity already registered
`
The app still runs because the flow engine resolves activities by full ref, but the errors are misleading and prevent the duplicate imports from getting usable aliases.

**What is the new behavior?**
When an implicitly derived alias (from path.Base()) collides with an already registered alias, the system now auto-generates a unique alias by prefixing the contribution name from the import path (e.g., query becomes MySQL_query, connection becomes SQLServer_connection). The collision is resolved silently at DEBUG log level — no more ERROR messages at startup. All imports get a valid, unique alias, so both full ref ("ref": "github.com/.../query") and shorthand alias ("ref": "#MySQL_query") references work correctly. Explicit user-provided aliases are not affected and still error on collision as before.