### PR TITLE
FLOGO-19401: Fix data race on the shared logger's tracing context

### DIFF
--- a/support/log/zap.go
+++ b/support/log/zap.go
@@ -12,10 +12,7 @@ import (
 
 var traceLogger *zap.SugaredLogger
 
-// traceState is the immutable pair of values derived from a tracing context.
-//
-// FLOGO-19401: it is published as a whole through an atomic.Value so a reader can
-// never observe a half-updated value. Once stored it is never mutated.
+// traceState is an immutable snapshot of a tracing context, published atomically.
 type traceState struct {
 	prefix  string
 	context map[string]string
@@ -25,23 +22,11 @@ type zapLoggerImpl struct {
 	loggerLevel *zap.AtomicLevel
 	mainLogger  *zap.SugaredLogger
 	// FLOGO-17735: add traceID and spanID attributes to log message
-	//
-	// FLOGO-19401: one logger is shared by every concurrently executing flow instance
-	// and activity - flow/action.go does `instLogger := logger` and only replaces it
-	// with a per-instance child when FLOGO_LOG_CTX=true, which is off by default. So
-	// SetTracingContext (flow/action.go:355,392,397 and flow/instance/taskinst.go:349)
-	// races with every log call on this logger.
-	//
-	// These were previously plain `string` and `map[string]string` fields. A Go string
-	// is a two-word {data, len} value and assigning one is not atomic, so a racing
-	// reader could observe the torn combination {data: nil, len: N}: the `!= ""` guard
-	// passes because len is non-zero, and the following concatenation then copies N
-	// bytes from address 0 and segfaults. Publish both values atomically instead.
+	// FLOGO-19401: atomic because the logger is shared across concurrent flows, and a torn read of a plain string field segfaults
 	traceState atomic.Value // holds *traceState; never stored nil
 }
 
-// tracePrefix returns the current trace prefix, or "" when no tracing context has
-// been set on this logger.
+// tracePrefix returns the current trace prefix, or "" if no tracing context is set.
 func (l *zapLoggerImpl) tracePrefix() string {
 	if ts, ok := l.traceState.Load().(*traceState); ok {
 		return ts.prefix

--- a/support/log/zap.go
+++ b/support/log/zap.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -11,12 +12,41 @@ import (
 
 var traceLogger *zap.SugaredLogger
 
+// traceState is the immutable pair of values derived from a tracing context.
+//
+// FLOGO-19401: it is published as a whole through an atomic.Value so a reader can
+// never observe a half-updated value. Once stored it is never mutated.
+type traceState struct {
+	prefix  string
+	context map[string]string
+}
+
 type zapLoggerImpl struct {
 	loggerLevel *zap.AtomicLevel
 	mainLogger  *zap.SugaredLogger
 	// FLOGO-17735: add traceID and spanID attributes to log message
-	tracePrefix  string
-	traceContext map[string]string
+	//
+	// FLOGO-19401: one logger is shared by every concurrently executing flow instance
+	// and activity - flow/action.go does `instLogger := logger` and only replaces it
+	// with a per-instance child when FLOGO_LOG_CTX=true, which is off by default. So
+	// SetTracingContext (flow/action.go:355,392,397 and flow/instance/taskinst.go:349)
+	// races with every log call on this logger.
+	//
+	// These were previously plain `string` and `map[string]string` fields. A Go string
+	// is a two-word {data, len} value and assigning one is not atomic, so a racing
+	// reader could observe the torn combination {data: nil, len: N}: the `!= ""` guard
+	// passes because len is non-zero, and the following concatenation then copies N
+	// bytes from address 0 and segfaults. Publish both values atomically instead.
+	traceState atomic.Value // holds *traceState; never stored nil
+}
+
+// tracePrefix returns the current trace prefix, or "" when no tracing context has
+// been set on this logger.
+func (l *zapLoggerImpl) tracePrefix() string {
+	if ts, ok := l.traceState.Load().(*traceState); ok {
+		return ts.prefix
+	}
+	return ""
 }
 
 func (l *zapLoggerImpl) DebugEnabled() bool {
@@ -34,9 +64,9 @@ func (l *zapLoggerImpl) Trace(args ...any) {
 }
 
 func (l *zapLoggerImpl) Debug(args ...any) {
-	if l.tracePrefix != "" {
+	if prefix := l.tracePrefix(); prefix != "" {
 		s := make([]any, 1, 1+len(args))
-		s[0] = l.tracePrefix
+		s[0] = prefix
 		l.mainLogger.Debug(append(s, args...)...)
 	} else {
 		l.mainLogger.Debug(args...)
@@ -44,9 +74,9 @@ func (l *zapLoggerImpl) Debug(args ...any) {
 }
 
 func (l *zapLoggerImpl) Info(args ...any) {
-	if l.tracePrefix != "" {
+	if prefix := l.tracePrefix(); prefix != "" {
 		s := make([]any, 1, 1+len(args))
-		s[0] = l.tracePrefix
+		s[0] = prefix
 		l.mainLogger.Info(append(s, args...)...)
 	} else {
 		l.mainLogger.Info(args...)
@@ -54,9 +84,9 @@ func (l *zapLoggerImpl) Info(args ...any) {
 }
 
 func (l *zapLoggerImpl) Warn(args ...any) {
-	if l.tracePrefix != "" {
+	if prefix := l.tracePrefix(); prefix != "" {
 		s := make([]any, 1, 1+len(args))
-		s[0] = l.tracePrefix
+		s[0] = prefix
 		l.mainLogger.Warn(append(s, args...)...)
 	} else {
 		l.mainLogger.Warn(args...)
@@ -64,9 +94,9 @@ func (l *zapLoggerImpl) Warn(args ...any) {
 }
 
 func (l *zapLoggerImpl) Error(args ...any) {
-	if l.tracePrefix != "" {
+	if prefix := l.tracePrefix(); prefix != "" {
 		s := make([]any, 1, 1+len(args))
-		s[0] = l.tracePrefix
+		s[0] = prefix
 		l.mainLogger.Error(append(s, args...)...)
 	} else {
 		l.mainLogger.Error(args...)
@@ -80,32 +110,32 @@ func (l *zapLoggerImpl) Tracef(template string, args ...any) {
 }
 
 func (l *zapLoggerImpl) Debugf(template string, args ...any) {
-	if l.tracePrefix != "" {
-		l.mainLogger.Debugf(l.tracePrefix+template, args...)
+	if prefix := l.tracePrefix(); prefix != "" {
+		l.mainLogger.Debugf(prefix+template, args...)
 	} else {
 		l.mainLogger.Debugf(template, args...)
 	}
 }
 
 func (l *zapLoggerImpl) Infof(template string, args ...any) {
-	if l.tracePrefix != "" {
-		l.mainLogger.Infof(l.tracePrefix+template, args...)
+	if prefix := l.tracePrefix(); prefix != "" {
+		l.mainLogger.Infof(prefix+template, args...)
 	} else {
 		l.mainLogger.Infof(template, args...)
 	}
 }
 
 func (l *zapLoggerImpl) Warnf(template string, args ...any) {
-	if l.tracePrefix != "" {
-		l.mainLogger.Warnf(l.tracePrefix+template, args...)
+	if prefix := l.tracePrefix(); prefix != "" {
+		l.mainLogger.Warnf(prefix+template, args...)
 	} else {
 		l.mainLogger.Warnf(template, args...)
 	}
 }
 
 func (l *zapLoggerImpl) Errorf(template string, args ...any) {
-	if l.tracePrefix != "" {
-		l.mainLogger.Errorf(l.tracePrefix+template, args...)
+	if prefix := l.tracePrefix(); prefix != "" {
+		l.mainLogger.Errorf(prefix+template, args...)
 	} else {
 		l.mainLogger.Errorf(template, args...)
 	}
@@ -116,19 +146,21 @@ func (l *zapLoggerImpl) Structured() StructuredLogger {
 }
 
 func (l *zapLoggerImpl) GetTracingContext() map[string]string {
-	return l.traceContext
+	if ts, ok := l.traceState.Load().(*traceState); ok {
+		return ts.context
+	}
+	return nil
 }
 
 func (l *zapLoggerImpl) SetTracingContext(traceContext map[string]string) {
 	if !traceContextLogging {
 		return
 	}
-	l.traceContext = traceContext
+	ts := &traceState{context: traceContext}
 	if traceContext != nil && traceContext[KeyTraceID] != "" {
-		l.tracePrefix = fmt.Sprintf("[%s: %s] [%s: %s] ", KeyTraceID, traceContext[KeyTraceID], KeySpanID, traceContext[KeySpanID])
-	} else {
-		l.tracePrefix = ""
+		ts.prefix = fmt.Sprintf("[%s: %s] [%s: %s] ", KeyTraceID, traceContext[KeyTraceID], KeySpanID, traceContext[KeySpanID])
 	}
+	l.traceState.Store(ts)
 }
 
 type zapStructuredLoggerImpl struct {

--- a/support/log/zap_test.go
+++ b/support/log/zap_test.go
@@ -1,0 +1,131 @@
+package log
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestSetTracingContext pins the observable behaviour of the trace prefix so the
+// atomic publication introduced for FLOGO-19401 cannot silently change it.
+func TestSetTracingContext(t *testing.T) {
+	prev := traceContextLogging
+	traceContextLogging = true
+	defer func() { traceContextLogging = prev }()
+
+	logger := NewLogger("flogo.test.tracingcontext").(*zapLoggerImpl)
+
+	if got := logger.tracePrefix(); got != "" {
+		t.Fatalf("new logger: tracePrefix = %q, want empty", got)
+	}
+	if got := logger.GetTracingContext(); got != nil {
+		t.Fatalf("new logger: GetTracingContext = %v, want nil", got)
+	}
+
+	tc := map[string]string{KeyTraceID: "4bf92f3577b34da6a3ce929d0e0e4736", KeySpanID: "00f067aa0ba902b7"}
+	logger.SetTracingContext(tc)
+
+	want := fmt.Sprintf("[%s: %s] [%s: %s] ", KeyTraceID, tc[KeyTraceID], KeySpanID, tc[KeySpanID])
+	if got := logger.tracePrefix(); got != want {
+		t.Errorf("after set: tracePrefix = %q, want %q", got, want)
+	}
+	if got := logger.GetTracingContext(); got[KeyTraceID] != tc[KeyTraceID] {
+		t.Errorf("after set: GetTracingContext[%s] = %q, want %q", KeyTraceID, got[KeyTraceID], tc[KeyTraceID])
+	}
+
+	logger.SetTracingContext(nil)
+	if got := logger.tracePrefix(); got != "" {
+		t.Errorf("after clear: tracePrefix = %q, want empty", got)
+	}
+	if got := logger.GetTracingContext(); got != nil {
+		t.Errorf("after clear: GetTracingContext = %v, want nil", got)
+	}
+
+	// A context carrying no trace id must not produce a prefix.
+	logger.SetTracingContext(map[string]string{KeySpanID: "00f067aa0ba902b7"})
+	if got := logger.tracePrefix(); got != "" {
+		t.Errorf("no trace id: tracePrefix = %q, want empty", got)
+	}
+}
+
+// TestSetTracingContextDisabled covers FLOGO_LOG_TRACE_CTX_ENABLED=false, which
+// must leave the logger untouched.
+func TestSetTracingContextDisabled(t *testing.T) {
+	prev := traceContextLogging
+	traceContextLogging = false
+	defer func() { traceContextLogging = prev }()
+
+	logger := NewLogger("flogo.test.tracingcontext.disabled").(*zapLoggerImpl)
+	logger.SetTracingContext(map[string]string{KeyTraceID: "abc", KeySpanID: "def"})
+
+	if got := logger.tracePrefix(); got != "" {
+		t.Errorf("tracing context logging disabled: tracePrefix = %q, want empty", got)
+	}
+	if got := logger.GetTracingContext(); got != nil {
+		t.Errorf("tracing context logging disabled: GetTracingContext = %v, want nil", got)
+	}
+}
+
+// TestSetTracingContextConcurrentWithLogging is the regression test for FLOGO-19401.
+//
+// A single logger is shared by every concurrently executing flow instance and
+// activity - flow/action.go does `instLogger := logger` and only replaces it with a
+// per-instance child when FLOGO_LOG_CTX=true, which is off by default. So
+// SetTracingContext (flow/action.go:355,392,397 and flow/instance/taskinst.go:349)
+// runs concurrently with log calls on that same logger.
+//
+// Before the fix the trace prefix was a plain string field. A Go string is a
+// two-word {data, len} value and assigning one is not atomic, so a racing reader
+// could observe {data: nil, len: N}: the `!= ""` guard passed because len was
+// non-zero, and the prefix concatenation then copied N bytes from address 0 and
+// segfaulted, taking the whole app down.
+//
+// Run with -race to catch the underlying data race deterministically. Without
+// -race this still exercises the crash, but only probabilistically.
+func TestSetTracingContextConcurrentWithLogging(t *testing.T) {
+	prev := traceContextLogging
+	traceContextLogging = true
+	defer func() { traceContextLogging = prev }()
+
+	logger := NewLogger("flogo.test.tracingcontext.race")
+	// Keep the test output quiet. The prefix is an argument to Debugf/Infof, so it is
+	// still built on every call regardless of the level - that is exactly why a
+	// production app running at ERROR was still crashing inside Debugf.
+	SetLogLevel(logger, ErrorLevel)
+
+	traceCtx := map[string]string{KeyTraceID: "4bf92f3577b34da6a3ce929d0e0e4736", KeySpanID: "00f067aa0ba902b7"}
+
+	const (
+		writers    = 2
+		readers    = 8
+		iterations = 5000
+	)
+
+	var wg sync.WaitGroup
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				logger.SetTracingContext(traceCtx)
+				logger.SetTracingContext(nil)
+			}
+		}()
+	}
+
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				logger.Debugf("Step: %d", i)
+				logger.Infof("Flow Instance [%d] completed", i)
+				logger.Debug("Scheduling task ", i)
+				logger.Info("Flow Instance ", i)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/support/log/zap_test.go
+++ b/support/log/zap_test.go
@@ -6,8 +6,7 @@ import (
 	"testing"
 )
 
-// TestSetTracingContext pins the observable behaviour of the trace prefix so the
-// atomic publication introduced for FLOGO-19401 cannot silently change it.
+// TestSetTracingContext pins the observable trace-prefix behaviour (FLOGO-19401).
 func TestSetTracingContext(t *testing.T) {
 	prev := traceContextLogging
 	traceContextLogging = true
@@ -48,8 +47,7 @@ func TestSetTracingContext(t *testing.T) {
 	}
 }
 
-// TestSetTracingContextDisabled covers FLOGO_LOG_TRACE_CTX_ENABLED=false, which
-// must leave the logger untouched.
+// TestSetTracingContextDisabled covers FLOGO_LOG_TRACE_CTX_ENABLED=false.
 func TestSetTracingContextDisabled(t *testing.T) {
 	prev := traceContextLogging
 	traceContextLogging = false
@@ -66,31 +64,14 @@ func TestSetTracingContextDisabled(t *testing.T) {
 	}
 }
 
-// TestSetTracingContextConcurrentWithLogging is the regression test for FLOGO-19401.
-//
-// A single logger is shared by every concurrently executing flow instance and
-// activity - flow/action.go does `instLogger := logger` and only replaces it with a
-// per-instance child when FLOGO_LOG_CTX=true, which is off by default. So
-// SetTracingContext (flow/action.go:355,392,397 and flow/instance/taskinst.go:349)
-// runs concurrently with log calls on that same logger.
-//
-// Before the fix the trace prefix was a plain string field. A Go string is a
-// two-word {data, len} value and assigning one is not atomic, so a racing reader
-// could observe {data: nil, len: N}: the `!= ""` guard passed because len was
-// non-zero, and the prefix concatenation then copied N bytes from address 0 and
-// segfaulted, taking the whole app down.
-//
-// Run with -race to catch the underlying data race deterministically. Without
-// -race this still exercises the crash, but only probabilistically.
+// TestSetTracingContextConcurrentWithLogging is the FLOGO-19401 regression test: SetTracingContext must be safe against concurrent log calls on a shared logger.
 func TestSetTracingContextConcurrentWithLogging(t *testing.T) {
 	prev := traceContextLogging
 	traceContextLogging = true
 	defer func() { traceContextLogging = prev }()
 
 	logger := NewLogger("flogo.test.tracingcontext.race")
-	// Keep the test output quiet. The prefix is an argument to Debugf/Infof, so it is
-	// still built on every call regardless of the level - that is exactly why a
-	// production app running at ERROR was still crashing inside Debugf.
+	// ERROR keeps the output quiet; the prefix is an argument so it is still built on every call.
 	SetLogLevel(logger, ErrorLevel)
 
 	traceCtx := map[string]string{KeyTraceID: "4bf92f3577b34da6a3ce929d0e0e4736", KeySpanID: "00f067aa0ba902b7"}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[] Feature
[] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[] Other... Please describe:
```

**Fixes**: FLOGO-19401

**What is the current behavior?**

Apps crash with an unrecovered `SIGSEGV` under concurrent load, and the container is restarted. Reported in the field as pods restarting under high traffic; three separate pods produced the same panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe58685]

github.com/project-flogo/core/support/log.(*zapLoggerImpl).Debugf(...)
	core/support/log/zap.go:84 +0x65
github.com/project-flogo/flow.(*FlowAction).Run.func1()
	flow/action.go:412 +0x39e
```

One `*zapLoggerImpl` is shared by every concurrently executing flow instance and activity — `flow/action.go` does `instLogger := logger` and only replaces it with a per-instance child when `FLOGO_LOG_CTX=true`, which is off by default. `SetTracingContext` therefore mutates that shared object while every log call on it reads the same fields, with no synchronisation:

| Role | Site |
|---|---|
| writer | `flow/action.go:355` — sets the prefix on flow start |
| writer | `flow/action.go:392`, `:397` — clears it on flow completion |
| writer | `flow/instance/taskinst.go:349` — sets it **per activity** |
| reader | `support/log/zap.go:84` — `l.mainLogger.Debugf(l.tracePrefix+template, args...)` |
| reader | `support/log/zap.go:92` — `l.mainLogger.Infof(l.tracePrefix+template, args...)` |

`tracePrefix` was a plain `string` field. A Go string is a two-word `{data *byte, len int}` value and assigning one is not atomic, so a racing reader could observe the torn combination `{data: nil, len: N}`:

- `zap.go:83` — the `l.tracePrefix != ""` guard passes, because `len` is non-zero
- `zap.go:84` — `l.tracePrefix + template` then copies `N` bytes from address `0`

Running the reproduction with `GOTRACEBACK=system` unhides the runtime frames and shows exactly that:

```
runtime.memmove()                                 <- faults; pc equals the signal pc
    runtime/memmove_amd64.s:215
runtime.concatstrings(...)
    runtime/string.go:56
runtime.concatstring2(_, {0x0?, 0x10?}, {...})    <- first string: data 0x0, len 16
    runtime/string.go:66
(*zapLoggerImpl).Debugf(...)
    support/log/zap.go:84 +0x65
```

Two things make this easy to hit:

1. The concatenation is an **argument** to `Debugf`, so it is evaluated on every call regardless of the configured log level. Apps running at INFO or ERROR still crash inside `Debugf`.
2. `DefaultLogTracingContextEnabled = true`, so no opt-in is required to reach the code.

`traceContext map[string]string` has the same problem — it is assigned unsynchronised on the line above.

**What is the new behavior?**

The prefix and the trace context are published together as one immutable `*traceState` held in an `atomic.Value`, so a reader always observes a complete, self-consistent state. Every log method loads it once into a local.

- Contained entirely in `support/log/zap.go`. No API change, no behaviour change.
- Uses `atomic.Value` rather than `atomic.Pointer[T]` so it stays within the module's existing `go 1.18` directive.
- Read-path cost is unchanged in practice — 209 M reads in 20 s patched vs 239 M unpatched in the stress harness.

**Testing**

Adds `support/log/zap_test.go` (the package previously had no tests):

- `TestSetTracingContext` — pins prefix set/clear/round-trip behaviour, including a context with no trace id
- `TestSetTracingContextDisabled` — covers `FLOGO_LOG_TRACE_CTX_ENABLED=false`
- `TestSetTracingContextConcurrentWithLogging` — the regression test: 2 writers against 8 readers exercising `Debugf`/`Infof`/`Debug`/`Info`. Reports a data race under `-race` before this change, clean after

Verified on Ubuntu 24.04, Go 1.25.11, 16 CPUs:

| Scenario | Before | After |
|---|---|---|
| stress harness, no race detector | `SIGSEGV addr=0x0` within approx 1 s | survives 20 s, 209 M log reads |
| stress harness, `-race` | `WARNING: DATA RACE`, exit 66 | clean |

`gofmt` and `go vet` are clean. `go test ./...` passes on 30 packages; the one failure, `TestURLStringToFilePath` in `support`, is a pre-existing Windows-only path-separator assertion that reproduces identically on unmodified `master`.

**Note for reviewers**

There is a related correctness issue this PR deliberately does **not** address: because the logger is shared, one flow's trace id can be stamped onto another flow's log lines. That is misleading observability data rather than a crash, and fixing it means giving each flow instance its own logger — a larger change in `flow`. Raising separately.
